### PR TITLE
Add MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,16 @@ set(FASTGPT_BLAS ${DEFAULT_FASTGPT_BLAS}
     CACHE BOOL "The BLAS library that fastGPT should use")
 if (NOT (FASTGPT_BLAS STREQUAL "Accelerate" OR
     FASTGPT_BLAS STREQUAL "OpenBLAS" OR
+    FASTGPT_BLAS STREQUAL "MKL" OR
     FASTGPT_BLAS STREQUAL "Fortran"))
-    message(FATAL_ERROR "FASTGPT_BLAS must be one of: OpenBLAS, Accelerate, Fortran (current value: '${FASTGPT_BLAS}')")
+    message(FATAL_ERROR "FASTGPT_BLAS must be one of: OpenBLAS, MKL, Accelerate, Fortran (current value: '${FASTGPT_BLAS}')")
 endif ()
 if (FASTGPT_BLAS STREQUAL "Accelerate")
     # pass
 elseif (FASTGPT_BLAS STREQUAL "OpenBLAS")
     find_package(OPENBLAS REQUIRED)
+elseif (FASTGPT_BLAS STREQUAL "MKL")
+    find_package(MKL CONFIG REQUIRED)
 else()
     # pass
 endif()
@@ -50,6 +53,8 @@ if (FASTGPT_BLAS STREQUAL "Accelerate")
 elseif (FASTGPT_BLAS STREQUAL "OpenBLAS")
     set(SRC ${SRC} linalg_openblas.c)
     set(SRC ${SRC} linalg_c.f90)
+elseif (FASTGPT_BLAS STREQUAL "MKL")
+    set(SRC ${SRC} linalg_mkl.f90)
 else()
     set(SRC ${SRC} linalg_f.f90)
 endif()
@@ -58,6 +63,9 @@ if (FASTGPT_BLAS STREQUAL "Accelerate")
     target_link_options(gpt2 PRIVATE -framework accelerate)
 elseif (FASTGPT_BLAS STREQUAL "OpenBLAS")
     target_link_libraries(gpt2 p::openblas)
+elseif (FASTGPT_BLAS STREQUAL "MKL")
+    target_compile_options(gpt2 PRIVATE $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
+    target_link_libraries(gpt2 PRIVATE $<LINK_ONLY:MKL::MKL>)
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,13 @@ Decoded output as text:
 You can choose which BLAS implementation to use for `matmul` using:
 * `-DFASTGPT_BLAS=OpenBLAS`: Use OpenBLAS
 * `-DFASTGPT_BLAS=Accelerate`: Use the macOS Accelerate Framework
+* `-DFASTGPT_BLAS=MKL`: Use the Intel oneMKL library
 * `-DFASTGPT_BLAS=Fortran`: Use the default Fortran's intrinsic `matmul`
+
+#### OneMKL
+
+MKL is supported via the oneMKL CMake config file (`MKLConfig.cmake`), available starting with the Intel® oneAPI Math Kernel Library (oneMKL) 2021.3 release. By default the config file will look for the `MKLROOT` environment variable. If the config file can't be located automatically use the manual directive: `-DMKL_DIR=<Full path to MKLConfig.cmake>`. Assuming a default installation you can initialize the MKL environment variables with the command: `source /opt/intel/oneapi/mkl/env/vars.sh`.
+
 
 ## Benchmarks
 

--- a/linalg_mkl.f90
+++ b/linalg_mkl.f90
@@ -10,14 +10,18 @@ contains
     real(sp), intent(in) :: A(:,:), B(:,:)
     real(sp), intent(out) :: C(:,:)
     
-    integer :: m, n, k
+    integer :: m, n, k, lda, ldb, ldc
     external :: sgemm
 
     m = size(A,1)
     n = size(B,2)
     k = size(A,2)
 
-    call sgemm('N','N',m,n,k,1.0_sp,A,size(A,1),B,size(B,1),0.0_sp,C,size(C,1))
+    lda = size(A,1)
+    ldb = size(B,1)
+    ldc = size(C,1)
+    
+    call sgemm('N','N',m,n,k,1.0_sp,A,lda,B,ldb,0.0_sp,C,ldc)
 
     end subroutine
 
@@ -25,14 +29,18 @@ contains
     ! C = matmul(transpose(A), B)
     real(sp), intent(in) :: A(:,:), B(:,:)
     real(sp), intent(out) :: C(:,:)
-    integer :: m, n, k
+    integer :: m, n, k, lda, ldb, ldc
     external :: sgemm
 
     m = size(A,1)
     n = size(B,2)
     k = size(A,2)
 
-    call sgemm('T','N',m,n,k,1.0_sp,A,size(A,1),B,size(B,1),0.0_sp,C,size(C,1))
+    lda = size(A,1)
+    ldb = size(B,1)
+    ldc = size(C,1)
+
+    call sgemm('T','N',m,n,k,1.0_sp,A,lda,B,ldb,0.0_sp,C,ldc)
 
     end subroutine
 

--- a/linalg_mkl.f90
+++ b/linalg_mkl.f90
@@ -1,0 +1,39 @@
+module linalg
+
+implicit none
+integer, parameter :: sp = kind(0.0)
+
+contains
+
+    subroutine matmul_2d(A, B, C)
+    ! C = matmul(A, B)
+    real(sp), intent(in) :: A(:,:), B(:,:)
+    real(sp), intent(out) :: C(:,:)
+    
+    integer :: m, n, k
+    external :: sgemm
+
+    m = size(A,1)
+    n = size(B,2)
+    k = size(A,2)
+
+    call sgemm('N','N',m,n,k,1.0_sp,A,size(A,1),B,size(B,1),0.0_sp,C,size(C,1))
+
+    end subroutine
+
+    subroutine matmul_2d_t(A, B, C)
+    ! C = matmul(transpose(A), B)
+    real(sp), intent(in) :: A(:,:), B(:,:)
+    real(sp), intent(out) :: C(:,:)
+    integer :: m, n, k
+    external :: sgemm
+
+    m = size(A,1)
+    n = size(B,2)
+    k = size(A,2)
+
+    call sgemm('T','N',m,n,k,1.0_sp,A,size(A,1),B,size(B,1),0.0_sp,C,size(C,1))
+
+    end subroutine
+
+end module


### PR DESCRIPTION
I've added CMake logic for the MKL library. This can be used to configure the build as follows:

```
ivan@maxwell:~/lrz/fastGPT-ivan/build$ FC=gfortran cmake .. -DFASTGPT_BLAS=MKL -DCMAKE_BUILD_TYPE=Release -DMKL_INTERFACE=lp64 -DMKL_LINK=static -DMKL_THREADING=sequential
```

It compiles and links successfully, but for some reasons fails at runtime with the following error:
```
...
Intel MKL ERROR: Parameter 13 was incorrect on entry to SGEMM .

Intel MKL INTERNAL ERROR: Condition -8 detected in function SGEMM .
          20           0
    done. Time:   0.765s
```
