### PR TITLE
CMake improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+gpt2/
+encoder.json
+input.dat
+model.dat
+vocab.bpe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_SOURCE_DIR}/cmake/UserOverride.cmake)
 
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release
+        CACHE STRING "Build type (Debug, Release)")
+endif()
+
 project(fastGPT)
 enable_language(Fortran)
 
@@ -9,12 +14,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod_files)
 
 # Make sure that CMAKE_BUILD_TYPE is either Debug or Release:
-if (NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release
-        CACHE STRING "Build type (Debug, Release)" FORCE)
-endif ()
-if (NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR
-        CMAKE_BUILD_TYPE STREQUAL "Release"))
+if (NOT CMAKE_BUILD_TYPE MATCHES "Debug|Release")
     message(FATAL_ERROR "CMAKE_BUILD_TYPE must be one of: Debug, Release (current value: '${CMAKE_BUILD_TYPE}')")
 endif ()
 
@@ -24,17 +24,21 @@ else()
     set(DEFAULT_FASTGPT_BLAS "Fortran")
 endif()
 set(FASTGPT_BLAS ${DEFAULT_FASTGPT_BLAS}
-    CACHE BOOL "The BLAS library that fastGPT should use")
-if (NOT (FASTGPT_BLAS STREQUAL "Accelerate" OR
-    FASTGPT_BLAS STREQUAL "OpenBLAS" OR
-    FASTGPT_BLAS STREQUAL "Fortran"))
+    CACHE STRING "The BLAS library that fastGPT should use")
+if (NOT FASTGPT_BLAS MATCHES "Accelerate|OpenBLAS|Fortran")
     message(FATAL_ERROR "FASTGPT_BLAS must be one of: OpenBLAS, Accelerate, Fortran (current value: '${FASTGPT_BLAS}')")
 endif ()
 if (FASTGPT_BLAS STREQUAL "Accelerate")
-    find_package(OMP REQUIRED)
+    find_package(OMP)
+    if(NOT OMP_FOUND)
+        find_package(OpenMP REQUIRED COMPONENTS Fortran)
+    endif()
 elseif (FASTGPT_BLAS STREQUAL "OpenBLAS")
     find_package(OPENBLAS REQUIRED)
-    find_package(OMP REQUIRED)
+    find_package(OMP)
+    if(NOT OMP_FOUND)
+        find_package(OpenMP REQUIRED COMPONENTS Fortran)
+    endif()
 else()
     # pass
 endif()
@@ -46,19 +50,19 @@ set(SRC
     gpt2.f90
     )
 if (FASTGPT_BLAS STREQUAL "Accelerate")
-    set(SRC ${SRC}
+    list(APPEND SRC
         linalg_accelerate.c
         linalg_c.f90
         omp.f90
     )
 elseif (FASTGPT_BLAS STREQUAL "OpenBLAS")
-    set(SRC ${SRC}
+    list(APPEND SRC
         linalg_openblas.c
         linalg_c.f90
         omp.f90
     )
 else()
-    set(SRC ${SRC}
+    list(APPEND SRC
         linalg_f.f90
         omp_dummy.f90
     )
@@ -66,10 +70,10 @@ endif()
 add_executable(gpt2 ${SRC})
 if (FASTGPT_BLAS STREQUAL "Accelerate")
     target_link_options(gpt2 PRIVATE -framework accelerate)
-    target_link_libraries(gpt2 p::omp)
+    target_link_libraries(gpt2 PRIVATE "$<IF:$<BOOL:${OMP_FOUND}>,p::omp,OpenMP::OpenMP_Fortran>")
 elseif (FASTGPT_BLAS STREQUAL "OpenBLAS")
-    target_link_libraries(gpt2 p::openblas)
-    target_link_libraries(gpt2 p::omp)
+    target_link_libraries(gpt2 p::openblas
+        "$<IF:$<BOOL:${OMP_FOUND}>,p::omp,OpenMP::OpenMP_Fortran>")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ elseif (FASTGPT_BLAS STREQUAL "OpenBLAS")
         "$<IF:$<BOOL:${OMP_FOUND}>,p::omp,OpenMP::OpenMP_Fortran>")
 endif()
 
+file(GENERATE OUTPUT .gitignore CONTENT "*")
 
 message("\n")
 message("Configuration results")

--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,10 @@
 
 set -ex
 
-FC=gfortran cmake .
-make
+FC=gfortran cmake -Bbuild
+cmake --build build --parallel
 python create_model.py --models_dir "../gpt2/models" --model_size "124M"
 python encode_input.py \
     "Alan Turing theorized that computers would one day become very powerful, but even he could not imagine" \
     -n 20
-./gpt2
+build/gpt2

--- a/cmake/FindOPENBLAS.cmake
+++ b/cmake/FindOPENBLAS.cmake
@@ -1,5 +1,6 @@
-find_path(OPENBLAS_INCLUDE_DIR cblas.h)
-find_library(OPENBLAS_LIBRARY openblas)
+find_path(OPENBLAS_INCLUDE_DIR NAMES cblas.h PATHS /usr/include/openblas)
+
+find_library(OPENBLAS_LIBRARY NAMES openblas)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(OPENBLAS DEFAULT_MSG OPENBLAS_INCLUDE_DIR

--- a/cmake/UserOverride.cmake
+++ b/cmake/UserOverride.cmake
@@ -10,10 +10,9 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     set(common "-Wall -Wextra -Wimplicit-interface -fPIC")
     set(CMAKE_Fortran_FLAGS_RELEASE_INIT "${common} -O3 -march=native -ffast-math -funroll-loops")
     set(CMAKE_Fortran_FLAGS_DEBUG_INIT   "${common} -g -fcheck=all -fbacktrace")
-elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+elseif (CMAKE_Fortran_COMPILER_ID MATCHES "^Intel")
     # ifort
     set(common "-warn all")
     set(CMAKE_Fortran_FLAGS_RELEASE_INIT "${common} -xHOST -O3 -no-prec-div -static")
     set(CMAKE_Fortran_FLAGS_DEBUG_INIT   "${common} -check all")
 endif ()
-


### PR DESCRIPTION
* I could not find OpenMP on macOS unless using find_package(OpenMP) built into CMake
* build in parallel with CMake and not needing to specifically have GNU Make
* actually set CMake build type
* use less typo-prone and canonical `list(APPEND ...)`
* use `if(... MATCHES ..)`