### PR TITLE
Adds basic support for MPI + LAMBADA dataset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ elseif (FASTGPT_BLAS STREQUAL "OpenBLAS")
 else()
     # pass
 endif()
+# Coarray support
+find_package(Coarray REQUIRED)
+find_package(Threads REQUIRED)
 
 enable_testing()
 
@@ -68,6 +71,7 @@ else()
     )
 endif()
 add_executable(gpt2 ${SRC})
+
 if (FASTGPT_BLAS STREQUAL "Accelerate")
     target_link_options(gpt2 PRIVATE -framework accelerate)
     target_link_libraries(gpt2 PRIVATE "$<IF:$<BOOL:${OMP_FOUND}>,p::omp,OpenMP::OpenMP_Fortran>")
@@ -75,6 +79,8 @@ elseif (FASTGPT_BLAS STREQUAL "OpenBLAS")
     target_link_libraries(gpt2 p::openblas
         "$<IF:$<BOOL:${OMP_FOUND}>,p::omp,OpenMP::OpenMP_Fortran>")
 endif()
+target_compile_options(gpt2 PRIVATE ${Coarray_COMPILE_OPTIONS})
+target_link_libraries(gpt2 PRIVATE ${Coarray_LIBRARIES})
 
 file(GENERATE OUTPUT .gitignore CONTENT "*")
 

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
 set -ex
-
+NP=4
 FC=gfortran cmake -Bbuild
-#FC=caf cmake -Bbuild
 cmake --build build --parallel
-# python create_model.py --models_dir "../gpt2/models" --model_size "124M"
+python create_model.py --models_dir "../gpt2/models" --model_size "124M"
 # python encode_input.py \
 #     "Alan Turing theorized that computers would one day become very powerful, but even he could not imagine" \
 #     -n 20
-cafrun -np 1 build/gpt2
+python encode_input.py "" -l 20 -n 20 # Downloads lambada dataset and selects -p prompts for input generation. Outputs are saved in output.txt in order
+cafrun -np $NP build/gpt2
+> output.txt
+for i in $(seq -w 01 $NP); do
+    cat output_$i.txt >> output.txt
+    rm -rf output_$i.txt
+done
+
+         

--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,10 @@
 set -ex
 
 FC=gfortran cmake -Bbuild
+#FC=caf cmake -Bbuild
 cmake --build build --parallel
-python create_model.py --models_dir "../gpt2/models" --model_size "124M"
-python encode_input.py \
-    "Alan Turing theorized that computers would one day become very powerful, but even he could not imagine" \
-    -n 20
-build/gpt2
+# python create_model.py --models_dir "../gpt2/models" --model_size "124M"
+# python encode_input.py \
+#     "Alan Turing theorized that computers would one day become very powerful, but even he could not imagine" \
+#     -n 20
+cafrun -np 1 build/gpt2

--- a/cmake/FindCoarray.cmake
+++ b/cmake/FindCoarray.cmake
@@ -1,0 +1,103 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindCoarray
+----------
+
+Finds compiler flags or library necessary to support Fortran 2008/2018 coarrays.
+
+This packages primary purposes are:
+
+* for compilers natively supporting Fortran coarrays without needing compiler options, simply indicating Coarray_FOUND  (example: Cray)
+* for compilers with built-in Fortran coarray support, enable compiler option (example: Intel Fortran)
+* for compilers needing a library such as OpenCoarrays, presenting library (example: GNU)
+
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+``Coarray_FOUND``
+  indicates coarray support found (whether built-in or library)
+
+``Coarray_LIBRARIES``
+  coarray library path
+``Coarray_COMPILE_OPTIONS``
+  coarray compiler options
+``Coarray_EXECUTABLE``
+  coarray executable e.g. ``cafrun``
+``Coarray_MAX_NUMPROCS``
+  maximum number of parallel processes
+``Coarray_NUMPROC_FLAG``
+  use for executing in parallel: ${Coarray_EXECUTABLE} ${Coarray_NUMPROC_FLAG} ${Coarray_MAX_NUMPROCS} ${CMAKE_CURRENT_BINARY_DIR}/myprogram
+  
+Cache Variables
+^^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``Coarray_LIBRARY``
+  The coarray libraries, if needed and found
+#]=======================================================================]
+
+cmake_policy(VERSION 3.3)
+
+set(options_coarray Intel)  # flags needed
+set(opencoarray_supported GNU)  # future: Flang, etc.
+
+unset(Coarray_COMPILE_OPTIONS)
+unset(Coarray_LIBRARY)
+unset(Coarray_REQUIRED_VARS)
+
+if(CMAKE_Fortran_COMPILER_ID IN_LIST options_coarray)
+
+  if(CMAKE_Fortran_COMPILER_ID STREQUAL Intel)
+    set(Coarray_COMPILE_OPTIONS -coarray=shared)
+    set(Coarray_LIBRARY -coarray=shared)  # ifort requires it at build AND link
+  endif()
+  
+  list(APPEND Coarray_REQUIRED_VARS ${Coarray_LIBRARY})
+
+elseif(CMAKE_Fortran_COMPILER_ID IN_LIST opencoarray_supported)
+
+  find_package(OpenCoarrays)
+
+  if(OpenCoarrays_FOUND)
+    set(Coarray_LIBRARY OpenCoarrays::caf_mpi)
+
+    set(Coarray_EXECUTABLE cafrun)
+
+    include(ProcessorCount)
+    ProcessorCount(Nproc)
+    set(Coarray_MAX_NUMPROCS ${Nproc})
+    set(Coarray_NUMPROC_FLAG -np)
+    
+    list(APPEND Coarray_REQUIRED_VARS ${Coarray_LIBRARY})
+  elseif(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
+    set(Coarray_COMPILE_OPTIONS -fcoarray=single)
+    list(APPEND Coarray_REQUIRED_VARS ${Coarray_COMPILE_OPTIONS})
+  endif()
+
+endif()
+
+
+set(CMAKE_REQUIRED_FLAGS ${Coarray_COMPILE_OPTIONS})
+set(CMAKE_REQUIRED_LIBRARIES ${Coarray_LIBRARY})
+include(CheckFortranSourceCompiles)
+check_fortran_source_compiles("program cs; real :: x[*]; end" f08coarray SRC_EXT f90)
+unset(CMAKE_REQUIRED_FLAGS)
+unset(CMAKE_REQUIRED_LIBRARIES)
+
+list(APPEND Coarray_REQUIRED_VARS ${f08coarray})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Coarray
+  REQUIRED_VARS Coarray_REQUIRED_VARS)
+
+set(Coarray_LIBRARIES ${Coarray_LIBRARY})
+
+
+mark_as_advanced(
+  Coarray_LIBRARY
+  Coarray_REQUIRED_VARS
+)

--- a/create_model.py
+++ b/create_model.py
@@ -218,6 +218,7 @@ def main(model_size: str = "124M", models_dir: str = "models"):
     # load encoder, hparams, and params from the released open-ai gpt-2 files
     t1 = clock()
     hparams, params = load_encoder_hparams_and_params(model_size, models_dir)
+    print(hparams)
     decoder = load_decoder(os.path.join(models_dir, model_size, "encoder.json"))
     t2 = clock()
     print("  Done. Loading time: ", t2-t1)
@@ -228,6 +229,7 @@ def main(model_size: str = "124M", models_dir: str = "models"):
     decoder_txt = "".join(decoder)
     idx = decoder_idx(decoder)
     byte_decoder = bytes_to_unicode()
+
     convert(params, hparams["n_head"], hparams["n_ctx"], idx, decoder_txt, byte_decoder)
     t2 = clock()
     print("  Done. Time: ", t2-t1)

--- a/encode_input.py
+++ b/encode_input.py
@@ -132,15 +132,22 @@ def get_encoder():
     bpe_merges = [tuple(merge_str.split()) for merge_str in bpe_data.split("\n")[1:-1]]
     return Encoder(encoder=encoder, bpe_merges=bpe_merges)
 
-def main(prompt: str, n_tokens_to_generate: int = 40):
+def main(prompt:str, l_prompts: int = 20, n_tokens_to_generate: int = 40):
     test_dataset = load_dataset("lambada", "plain_text", split="test")
     encoder = get_encoder()
     with open("input.dat", "w") as f:
-        for i, prompt in enumerate(test_dataset["text"]):
-            input_ids = np.array(encoder.encode(prompt), dtype=np.int32)
-            # Write two lines
-            np.array([len(input_ids), n_tokens_to_generate], dtype=np.int32).tofile(f)        
-            input_ids.tofile(f)
+            if(len(prompt) == 0):
+                input_count = len(test_dataset["text"][:l_prompts])
+                np.array([input_count], dtype=np.int32).tofile(f)
+                for i, prompt in enumerate(test_dataset["text"][:l_prompts]):
+                    input_ids = np.array(encoder.encode(prompt), dtype=np.int32)
+                    np.array([len(input_ids), n_tokens_to_generate], dtype=np.int32).tofile(f)        
+                    input_ids.tofile(f)
+            else:
+                input_ids = np.array(encoder.encode(prompt), dtype=np.int32)
+                np.array([len(input_ids), n_tokens_to_generate], dtype=np.int32).tofile(f)
+                input_ids.tofile(f)
+                print(input_ids)                
 
 if __name__ == "__main__":
     import fire

--- a/encode_input.py
+++ b/encode_input.py
@@ -43,6 +43,7 @@ import numpy as np
 import json
 import os
 import regex as re
+from datasets import load_dataset
 
 def bytes_to_unicode():
     bs = list(range(ord("!"), ord("~") + 1)) + list(range(ord("¡"), ord("¬") + 1)) + list(range(ord("®"), ord("ÿ") + 1))
@@ -132,14 +133,14 @@ def get_encoder():
     return Encoder(encoder=encoder, bpe_merges=bpe_merges)
 
 def main(prompt: str, n_tokens_to_generate: int = 40):
+    test_dataset = load_dataset("lambada", "plain_text", split="test")
     encoder = get_encoder()
-    input_ids = np.array(encoder.encode(prompt), dtype=np.int32)
-
-    print("Saving the input into `input.dat`")
-    g = open("input.dat", "w")
-    np.array([len(input_ids), n_tokens_to_generate], dtype=np.int32).tofile(g)
-    input_ids.tofile(g)
-    print(input_ids)
+    with open("input.dat", "w") as f:
+        for i, prompt in enumerate(test_dataset["text"]):
+            input_ids = np.array(encoder.encode(prompt), dtype=np.int32)
+            # Write two lines
+            np.array([len(input_ids), n_tokens_to_generate], dtype=np.int32).tofile(f)        
+            input_ids.tofile(f)
 
 if __name__ == "__main__":
     import fire

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -261,7 +261,7 @@ do i = 1, n_tokens_to_generate
             attn_w, attn_b, attn_proj_w, attn_proj_b, &
             ln1_g, ln1_b, ln2_g, ln2_b, lnf_g, lnf_b, use_kv_cache, kv_cache(:,:n_seq2,:,:))
     next_id = maxloc(logits(:,n_seq_x), dim=1)-1
-    print *, i, next_id
+    ! print *, i, next_id
     input2(n_seq + i) = next_id
     deallocate(logits)
  end do

--- a/main.f90
+++ b/main.f90
@@ -1,107 +1,113 @@
 program gpt2
-use gpt2_mod, only: generate, decode
-use omp, only: omp_get_wtime
-implicit none
+   use gpt2_mod, only: generate, decode
+   use omp, only: omp_get_wtime
+   implicit none
 
-integer, parameter :: sp = kind(0.0)
-integer, parameter :: dp = kind(0.d0)
+   integer, parameter :: sp = kind(0.0)
+   integer, parameter :: dp = kind(0.d0)
 
-integer :: n_vocab, n_ctx, n_seq, n_embd, n_layer, n_head, &
-    n_tokens_to_generate, n_decoder_idx, n_decoder_txt, n_byte_decoder
-integer, allocatable :: input(:), decoder_idx(:), byte_decoder(:)
-real(sp), allocatable :: wte(:,:), wpe(:,:), &
-    mlp_fc_w(:,:,:), mlp_fc_b(:,:), &
-    mlp_proj_w(:,:,:), mlp_proj_b(:,:), &
-    attn_w(:,:,:), attn_b(:,:), &
-    attn_proj_w(:,:,:), attn_proj_b(:,:), &
-    ln1_b(:,:), ln1_g(:,:), &
-    ln2_b(:,:), ln2_g(:,:), &
-    lnf_b(:), lnf_g(:)
-character, allocatable :: decoder_txt(:)
-integer, allocatable :: output(:)
-character(:), allocatable :: output_txt
-real(dp) :: t1, t2, t1o, t2o
-integer :: u
-logical :: use_cache
+   integer :: n_vocab, n_ctx, n_seq, n_embd, n_layer, n_head, &
+              n_tokens_to_generate, n_decoder_idx, n_decoder_txt, n_byte_decoder
+   integer, allocatable :: input(:), decoder_idx(:), byte_decoder(:)
+   real(sp), allocatable :: wte(:, :), wpe(:, :), &
+                            mlp_fc_w(:, :, :), mlp_fc_b(:, :), &
+                            mlp_proj_w(:, :, :), mlp_proj_b(:, :), &
+                            attn_w(:, :, :), attn_b(:, :), &
+                            attn_proj_w(:, :, :), attn_proj_b(:, :), &
+                            ln1_b(:, :), ln1_g(:, :), &
+                            ln2_b(:, :), ln2_g(:, :), &
+                            lnf_b(:), lnf_g(:)
+   character, allocatable :: decoder_txt(:)
+   integer, allocatable :: output(:)
+   character(:), allocatable :: output_txt
+   real(dp) :: t1, t2, t1o, t2o
+   integer :: u, i
+   logical :: use_cache
 
 ! Load the model
-print "(a)", "Loading the model..."
-call cpu_time(t1)
-open(newunit=u, file="model.dat", form="unformatted", access="stream", status="old")
-read(u) n_vocab, n_ctx, n_embd, n_layer, n_head, n_decoder_idx, n_decoder_txt, &
-    n_byte_decoder
-allocate(wte(n_embd,n_vocab), wpe(n_embd,n_ctx), &
-    mlp_fc_w(4*n_embd,n_embd,n_layer), mlp_fc_b(4*n_embd,n_layer), &
-    mlp_proj_w(n_embd,4*n_embd,n_layer), mlp_proj_b(n_embd,n_layer), &
-    attn_w(3*n_embd,n_embd,n_layer), attn_b(3*n_embd,n_layer), &
-    attn_proj_w(n_embd,n_embd,n_layer), attn_proj_b(n_embd,n_layer), &
-    ln1_b(n_embd,n_layer), ln1_g(n_embd,n_layer), &
-    ln2_b(n_embd,n_layer), ln2_g(n_embd,n_layer), &
-    lnf_b(n_embd), lnf_g(n_embd), &
-    decoder_idx(n_decoder_idx), decoder_txt(n_decoder_txt), &
-    byte_decoder(n_byte_decoder))
-read(u) wte, wpe, &
-    mlp_fc_w, mlp_fc_b, &
-    mlp_proj_w, mlp_proj_b, &
-    attn_w, attn_b, &
-    attn_proj_w, attn_proj_b, &
-    ln1_b, ln1_g, &
-    ln2_b, ln2_g, &
-    lnf_b, lnf_g, &
-    decoder_idx, decoder_txt, byte_decoder
-close(u)
-call cpu_time(t2)
-print "(a,f8.3,a)", "    done. Time:", t2-t1, "s"
+   print "(a)", "Loading the model..."
+   call cpu_time(t1)
+   open (newunit=u, file="model.dat", form="unformatted", access="stream", status="old")
+   read (u) n_vocab, n_ctx, n_embd, n_layer, n_head, n_decoder_idx, n_decoder_txt, &
+      n_byte_decoder
+   allocate (wte(n_embd, n_vocab), wpe(n_embd, n_ctx), &
+             mlp_fc_w(4*n_embd, n_embd, n_layer), mlp_fc_b(4*n_embd, n_layer), &
+             mlp_proj_w(n_embd, 4*n_embd, n_layer), mlp_proj_b(n_embd, n_layer), &
+             attn_w(3*n_embd, n_embd, n_layer), attn_b(3*n_embd, n_layer), &
+             attn_proj_w(n_embd, n_embd, n_layer), attn_proj_b(n_embd, n_layer), &
+             ln1_b(n_embd, n_layer), ln1_g(n_embd, n_layer), &
+             ln2_b(n_embd, n_layer), ln2_g(n_embd, n_layer), &
+             lnf_b(n_embd), lnf_g(n_embd), &
+             decoder_idx(n_decoder_idx), decoder_txt(n_decoder_txt), &
+             byte_decoder(n_byte_decoder))
+   read (u) wte, wpe, &
+      mlp_fc_w, mlp_fc_b, &
+      mlp_proj_w, mlp_proj_b, &
+      attn_w, attn_b, &
+      attn_proj_w, attn_proj_b, &
+      ln1_b, ln1_g, &
+      ln2_b, ln2_g, &
+      lnf_b, lnf_g, &
+      decoder_idx, decoder_txt, byte_decoder
+   close (u)
+   call cpu_time(t2)
+   print "(a,f8.3,a)", "    done. Time:", t2 - t1, "s"
+
+   print "(i4, a, i4)", i, "Image Id:", this_image()
+   print "(a)", "Model parameters:"
+   print "(a,i6)", "n_vocab =", n_vocab
+   print "(a,i6)", "n_ctx   =", n_ctx
+   print "(a,i6)", "n_embd  =", n_embd
+   print "(a,i6)", "n_layer =", n_layer
+   print "(a,i6)", "n_head  =", n_head
+   print *
 
 ! Load the input
-open(newunit=u, file="input.dat", form="unformatted", access="stream", status="old")
-read(u) n_seq, n_tokens_to_generate
-allocate(input(n_seq))
-read(u) input
-close(u)
+   i = 0
+   open (newunit=u, file="input.dat", form="unformatted", access="stream", status="old")
+1  read (u, end=2) n_seq, n_tokens_to_generate
+   if (allocated(input)) deallocate (input)
+   allocate (input(n_seq))
+   read (u) input
+   i = i + 1
+   goto 1
+2  close (u)
 
-print "(a)", "Model parameters:"
-print "(a,i6)", "n_vocab =", n_vocab
-print "(a,i6)", "n_ctx   =", n_ctx
-print "(a,i6)", "n_embd  =", n_embd
-print "(a,i6)", "n_layer =", n_layer
-print "(a,i6)", "n_head  =", n_head
-print *
-print "(a)", "Input parameters:"
-print "(a,i4)", "n_seq                =", n_seq
-print "(a,i4)", "n_tokens_to_generate =", n_tokens_to_generate
+   print "(a)", "Input parameters:"
+   print "(a,i4)", "n_seq                =", n_seq
+   print "(a,i4)", "n_tokens_to_generate =", n_tokens_to_generate
 
-if (n_seq + n_tokens_to_generate >= n_ctx) then
-    print *, "The maximum sequence length of the model was surpassed."
-    print *, "Make the input and/or number of tokens to generate shorter."
-    error stop
-end if
+   if (n_seq + n_tokens_to_generate >= n_ctx) then
+      print *, "The maximum sequence length of the model was surpassed."
+      print *, "Make the input and/or number of tokens to generate shorter."
+      error stop
+   end if
 
-print *
-print "(a)", "Input tokens:"
-print "(1000(i6))", input
-print "(a)", "Decoded input as text:"
-print "(a)", decode(input, decoder_idx, decoder_txt, byte_decoder)
+   print *
+   print "(a)", "Input tokens:"
+   print "(1000(i6))", input
+   print "(a)", "Decoded input as text:"
+   print "(a)", decode(input, decoder_idx, decoder_txt, byte_decoder)
 
-allocate(output(n_tokens_to_generate))
-print "(a)", "Running model..."
-call cpu_time(t1)
-t1o = omp_get_wtime()
-use_cache = .true.
-output = generate(n_tokens_to_generate, n_vocab, n_ctx, size(input), n_embd, &
-    n_layer, n_head, &
-    input, &
-    wte, wpe, &
-    mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b, &
-    attn_w, attn_b, attn_proj_w, attn_proj_b, &
-    ln1_g, ln1_b, ln2_g, ln2_b, lnf_g, lnf_b, use_cache)
-t2o = omp_get_wtime()
-call cpu_time(t2)
-print "(a,f8.3,a,f4.2,a)", "    done. Time:", t2o-t1o, "s (", (t2-t1)/(t2o-t1o), "x)"
-print "(a)", "Output tokens:"
-print "(1000(i6))", output
-allocate(character(0) :: output_txt) ! Fix GFortran warning
-output_txt = decode(output, decoder_idx, decoder_txt, byte_decoder)
-print "(a)", "Decoded output as text:"
-print "(a)", output_txt
+   allocate (output(n_tokens_to_generate))
+   print "(a)", "Running model..."
+   call cpu_time(t1)
+   t1o = omp_get_wtime()
+   use_cache = .true.
+   output = generate(n_tokens_to_generate, n_vocab, n_ctx, size(input), n_embd, &
+                     n_layer, n_head, &
+                     input, &
+                     wte, wpe, &
+                     mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b, &
+                     attn_w, attn_b, attn_proj_w, attn_proj_b, &
+                     ln1_g, ln1_b, ln2_g, ln2_b, lnf_g, lnf_b, use_cache)
+   t2o = omp_get_wtime()
+   call cpu_time(t2)
+   print "(a,f8.3,a,f4.2,a)", "    done. Time:", t2o - t1o, "s (", (t2 - t1)/(t2o - t1o), "x)"
+   print "(a)", "Output tokens:"
+   print "(1000(i6))", output
+   allocate (character(0) :: output_txt) ! Fix GFortran warning
+   output_txt = decode(output, decoder_idx, decoder_txt, byte_decoder)
+   print "(a)", "Decoded output as text:"
+   print "(a)", output_txt
 end program

--- a/main.f90
+++ b/main.f90
@@ -19,7 +19,6 @@ program gpt2
                             lnf_b(:), lnf_g(:)
    character, allocatable :: decoder_txt(:)
    integer, allocatable :: output(:)
-   character(:), allocatable :: output_txt
    real(dp) :: t1, t2, t1o, t2o
    integer :: u, i, total_input, chunk, start, end_, dummy, j, w, stat
    logical :: use_cache, exists

--- a/main.f90
+++ b/main.f90
@@ -21,13 +21,14 @@ program gpt2
    integer, allocatable :: output(:)
    character(:), allocatable :: output_txt
    real(dp) :: t1, t2, t1o, t2o
-   integer :: u, i
-   logical :: use_cache
+   integer :: u, i, total_input, chunk, start, end_, dummy, j, w, stat
+   logical :: use_cache, exists
+   character(len=13) output_file
 
 ! Load the model
-   print "(a)", "Loading the model..."
    call cpu_time(t1)
    open (newunit=u, file="model.dat", form="unformatted", access="stream", status="old")
+
    read (u) n_vocab, n_ctx, n_embd, n_layer, n_head, n_decoder_idx, n_decoder_txt, &
       n_byte_decoder
    allocate (wte(n_embd, n_vocab), wpe(n_embd, n_ctx), &
@@ -51,63 +52,73 @@ program gpt2
       decoder_idx, decoder_txt, byte_decoder
    close (u)
    call cpu_time(t2)
-   print "(a,f8.3,a)", "    done. Time:", t2 - t1, "s"
 
-   print "(i4, a, i4)", i, "Image Id:", this_image()
-   print "(a)", "Model parameters:"
-   print "(a,i6)", "n_vocab =", n_vocab
-   print "(a,i6)", "n_ctx   =", n_ctx
-   print "(a,i6)", "n_embd  =", n_embd
-   print "(a,i6)", "n_layer =", n_layer
-   print "(a,i6)", "n_head  =", n_head
-   print *
-
-! Load the input
-   i = 0
-   open (newunit=u, file="input.dat", form="unformatted", access="stream", status="old")
-1  read (u, end=2) n_seq, n_tokens_to_generate
-   if (allocated(input)) deallocate (input)
-   allocate (input(n_seq))
-   read (u) input
-   i = i + 1
-   goto 1
-2  close (u)
-
-   print "(a)", "Input parameters:"
-   print "(a,i4)", "n_seq                =", n_seq
-   print "(a,i4)", "n_tokens_to_generate =", n_tokens_to_generate
-
-   if (n_seq + n_tokens_to_generate >= n_ctx) then
-      print *, "The maximum sequence length of the model was surpassed."
-      print *, "Make the input and/or number of tokens to generate shorter."
-      error stop
+   ! print "(a, i4)", "Image Id:", this_image()
+   if (this_image() == 1) then
+      print "(a,f8.3,a)", "    done. Time:", t2 - t1, "s"
+      print "(a)", "Model parameters:"
+      print "(a,i6)", "n_vocab =", n_vocab
+      print "(a,i6)", "n_ctx   =", n_ctx
+      print "(a,i6)", "n_embd  =", n_embd
+      print "(a,i6)", "n_layer =", n_layer
+      print "(a,i6)", "n_head  =", n_head
+      print *
+      print "(a)", "Running model..."
    end if
 
-   print *
-   print "(a)", "Input tokens:"
-   print "(1000(i6))", input
-   print "(a)", "Decoded input as text:"
-   print "(a)", decode(input, decoder_idx, decoder_txt, byte_decoder)
+! Load the input and prepare the output file
+   open (newunit=u, file="input.dat", form="unformatted", access="stream", status="old")
+   write (output_file, '(a,i2.2,a)') "output_", this_image(), ".txt"
+   inquire (file=output_file, exist=exists)
+   if (exists) then
+      open (file=output_file, newunit=w, iostat=stat)
+      if (stat == 0) close (w, status="delete", iostat=stat)
+   end if
 
-   allocate (output(n_tokens_to_generate))
-   print "(a)", "Running model..."
-   call cpu_time(t1)
-   t1o = omp_get_wtime()
-   use_cache = .true.
-   output = generate(n_tokens_to_generate, n_vocab, n_ctx, size(input), n_embd, &
-                     n_layer, n_head, &
-                     input, &
-                     wte, wpe, &
-                     mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b, &
-                     attn_w, attn_b, attn_proj_w, attn_proj_b, &
-                     ln1_g, ln1_b, ln2_g, ln2_b, lnf_g, lnf_b, use_cache)
-   t2o = omp_get_wtime()
-   call cpu_time(t2)
-   print "(a,f8.3,a,f4.2,a)", "    done. Time:", t2o - t1o, "s (", (t2 - t1)/(t2o - t1o), "x)"
-   print "(a)", "Output tokens:"
-   print "(1000(i6))", output
-   allocate (character(0) :: output_txt) ! Fix GFortran warning
-   output_txt = decode(output, decoder_idx, decoder_txt, byte_decoder)
-   print "(a)", "Decoded output as text:"
-   print "(a)", output_txt
+   open (newunit=w, file=output_file, position="append", status="new", action="write")
+   ! Read total lines
+   read (u) total_input
+   chunk = (total_input + num_images() - 1)/num_images()
+   start = (this_image() - 1)*chunk
+   end_ = start + chunk
+   print *, "Image Id:", this_image(), "Range:", start, end_ - 1
+   do i = 0, start - 1
+      read (u, end=1) n_seq, n_tokens_to_generate
+      read (u) (dummy, j=1, n_seq)                   !Skip line
+   end do
+   do i = start, end_ - 1
+      read (u, end=1) n_seq, n_tokens_to_generate
+      if (allocated(input)) deallocate (input)
+      allocate (input(n_seq))
+      read (u, end=1) input
+      ! Check n_ctx Bound
+      if (n_seq + n_tokens_to_generate >= n_ctx) then
+         print *, "The maximum sequence length of the model was surpassed."
+         print *, "Make the input and/or number of tokens to generate shorter."
+         error stop
+      end if
+      ! Set timers
+      call cpu_time(t1)
+      t1o = omp_get_wtime()
+      ! Run generation
+      use_cache = .true.
+      if (allocated(output)) deallocate (output)
+      allocate (output(n_tokens_to_generate))
+      output = generate(n_tokens_to_generate, n_vocab, n_ctx, size(input), n_embd, &
+                        n_layer, n_head, &
+                        input, &
+                        wte, wpe, &
+                        mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b, &
+                        attn_w, attn_b, attn_proj_w, attn_proj_b, &
+                        ln1_g, ln1_b, ln2_g, ln2_b, lnf_g, lnf_b, use_cache)
+      t2o = omp_get_wtime()
+      call cpu_time(t2)
+      ! FIXME: Time difference in seconds is always zero in ubuntu
+      print "(a,i4,a,f8.3,a,f4.2,a)", "Sample:", i, "|Time:", t2o - t1o, "s (", (t2 - t1)/(t2o - t1o), "x)"
+      write (w, '(a, a)') decode(input, decoder_idx, decoder_txt, byte_decoder), &
+           decode(output, decoder_idx, decoder_txt, byte_decoder)
+      flush (w)
+   end do
+1  close (u)
+   close (w)
 end program

--- a/pt.py
+++ b/pt.py
@@ -10,7 +10,8 @@ t1 = clock()
 generator = pipeline('text-generation', model='gpt2')
 t2 = clock()
 print("  Time: ", t2-t1)
-text="Alan Turing theorized that computers would one day become very powerful, but even he could not imagine"
+#text="Alan Turing theorized that computers would one day become very powerful, but even he could not imagine"
+text="`` yes , grandmother , and do n't worry , i wo n't forget my water when i go wander . '' her brothers laughed a little only because the comment was so cute . `` wonderful my little wanderer , because i would hate to think of you forgetting an important rule like that . '' `` i would never forget the rules , grandmother"
 print("Generating")
 t1 = clock()
 g = generator(text, do_sample=False, max_new_tokens=20, use_cache=True)

--- a/pt.py
+++ b/pt.py
@@ -10,8 +10,7 @@ t1 = clock()
 generator = pipeline('text-generation', model='gpt2')
 t2 = clock()
 print("  Time: ", t2-t1)
-#text="Alan Turing theorized that computers would one day become very powerful, but even he could not imagine"
-text="`` yes , grandmother , and do n't worry , i wo n't forget my water when i go wander . '' her brothers laughed a little only because the comment was so cute . `` wonderful my little wanderer , because i would hate to think of you forgetting an important rule like that . '' `` i would never forget the rules , grandmother"
+text="Alan Turing theorized that computers would one day become very powerful, but even he could not imagine"
 print("Generating")
 t1 = clock()
 g = generator(text, do_sample=False, max_new_tokens=20, use_cache=True)


### PR DESCRIPTION
- I wanted to evaluate the FORTRAN implementation on the LAMBADA dataset. It would be nice to match the evaluation metrics reported here - https://huggingface.co/gpt2
- I have seen implementations from other language being published to HuggingFace. Do you have plans of publishing it there? I don't know much about it either. But, I am curious.
- Ended up adding basic MPI support. 
- I wanted to implement the perplexity metric but the PR was getting bigger. So, I figured I'd share what I have. To implement perplexity, we need to calculate loss. To calculate loss, we have to truncate the sequence length to total - num_tokens_to_generate and use that as the target. Loss = NLL(generated_output, target); Then, Perplexity = exp(sum(losses)/num_generated_tokens)

Thanks for creating this project!