### PR TITLE
Implement fast_erf() and fast_gelu()

### DIFF
--- a/gpt2.f90
+++ b/gpt2.f90
@@ -43,6 +43,21 @@ else
 end if
 end function
 
+elemental real function fast_erf(x) result(y)
+real(sp), intent(in) :: x
+real(sp) :: abs_x
+abs_x = abs(x)
+y = 1 - 1 / (1+ abs_x * (0.278393 + abs_x * (0.230389 + abs_x * (0.000972 + 0.078108*abs_x))))**4
+y = merge(y, -y, x >= 0)
+end function
+
+elemental real function fast_gelu(x) result(y)
+real(sp), intent(in) :: x
+real(sp), parameter :: inverse_root_2 = 1 / sqrt(2._sp)
+y = 0.5_sp * x * (1 + fast_erf(x * inverse_root_2))
+end function
+
+
 elemental real(sp) function gelu(x) result(y)
 real(sp), intent(in) :: x
 y = 0.5_sp * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715_sp * x**3)))


### PR DESCRIPTION
This approximates the erf() function directly.

To use it, apply the following patch:
```diff
--- a/gpt2.f90
+++ b/gpt2.f90
@@ -109,7 +109,7 @@ real(sp), intent(in) :: x(:,:), fc_w(:,:), fc_b(:), proj_w(:,:), proj_b(:)
 real(sp) :: y(size(x,1),size(x,2))
 !real(sp) :: a(4*size(x,1),size(x,2))
 !a = gelu(linear(x, fc_w, fc_b))
-y = linear(gelu(linear(x, fc_w, fc_b)), proj_w, proj_b)
+y = linear(fast_gelu(linear(x, fc_w, fc_b)), proj_w, proj_b)
 end function
 
 function attention(n_embd_head,n_seq,n_seq_x, q, k, v, mask) result(y)
```