### PR TITLE
This PR makes fastGPT work with current LFortran

### DIFF
--- a/chat.f90
+++ b/chat.f90
@@ -1,5 +1,7 @@
 program chatgpt2
 use driver, only: chat
+use tokenizer, only: string
 implicit none
-call chat()
+type(string), allocatable :: inputs(:)
+call chat(.false., inputs)
 end program

--- a/driver.f90
+++ b/driver.f90
@@ -17,11 +17,11 @@ character(:), allocatable, intent(out) :: input_txt
 integer, intent(out) :: n_tokens_to_generate
 character(1024) :: input_txt2
 integer :: u, ios
-namelist / input_fastGPT / n_tokens_to_generate
+!namelist / input_fastGPT / n_tokens_to_generate
 allocate(character(0) :: input_txt)
 input_txt = ""
 open(newunit=u, file=filename, status="old")
-read(u, input_fastGPT)
+!read(u, input_fastGPT)
 do
     read(u, "(a)", iostat=ios) input_txt2
     if (ios /= 0) exit

--- a/driver.f90
+++ b/driver.f90
@@ -147,6 +147,11 @@ print "(a)", "Input tokens:"
 !print "(1000(i6))", input
 print *, input
 print *
+if (n_seq /= 19) error stop
+if (input(1) /= 36235) error stop
+if (input(2) /= 39141) error stop
+if (input(18) /= 407) error stop
+if (input(19) /= 5967) error stop
 
 if (n_seq + n_tokens_to_generate >= m%n_ctx) then
     print *, "The maximum sequence length of the model was surpassed."

--- a/driver.f90
+++ b/driver.f90
@@ -19,16 +19,17 @@ character(1024) :: input_txt2
 integer :: u, ios
 !namelist / input_fastGPT / n_tokens_to_generate
 allocate(character(0) :: input_txt)
-input_txt = ""
-open(newunit=u, file=filename, status="old")
+n_tokens_to_generate = 20
+input_txt = "Alan Turing theorized that computers would one day become very powerful, but even he could not imagine"
+!open(newunit=u, file=filename, status="old")
 !read(u, input_fastGPT)
-do
-    read(u, "(a)", iostat=ios) input_txt2
-    if (ios /= 0) exit
-    if (len(input_txt) > 0) input_txt = input_txt // char(10)
-    input_txt = input_txt // trim(input_txt2)
-end do
-close(u)
+!do
+!    read(u, "(a)", iostat=ios) input_txt2
+!    if (ios /= 0) exit
+!    if (len(input_txt) > 0) input_txt = input_txt // char(10)
+!    input_txt = input_txt // trim(input_txt2)
+!end do
+!close(u)
 end subroutine
 
 subroutine load_model(filename, m)

--- a/driver.f90
+++ b/driver.f90
@@ -174,7 +174,7 @@ allocate(output(n_tokens_to_generate))
 print "(a)", "Running model..."
 call cpu_time(t1)
 t1o = omp_get_wtime()
-use_cache = .false.
+use_cache = .true.
 call generate(output, n_tokens_to_generate, m, size(input), input, use_cache, &
     byte_decoder)
 print *

--- a/driver.f90
+++ b/driver.f90
@@ -184,10 +184,10 @@ print "(a,f8.3,a,f4.2,a)", "    done. Time:", t2o-t1o, "s (", (t2-t1)/(t2o-t1o),
 print *
 print "(a)", "Output tokens:"
 print *, output
-!output_txt = decode(output, m%decoder_idx, m%decoder_txt, byte_decoder)
-!print *
-!print "(a)", "Decoded output as text:"
-!print "(a)", output_txt
+output_txt = decode(output, m%decoder_idx, m%decoder_txt, byte_decoder)
+print *
+print "(a)", "Decoded output as text:"
+print *, output_txt
 if (output(1) /= 703) error stop
 if (output(2) /= 484) error stop
 if (output(19) /= 1517) error stop

--- a/driver.f90
+++ b/driver.f90
@@ -143,7 +143,8 @@ print "(a,i4)", "n_seq                =", n_seq
 print "(a,i4)", "n_tokens_to_generate =", n_tokens_to_generate
 print *
 print "(a)", "Input tokens:"
-print "(1000(i6))", input
+!print "(1000(i6))", input
+print *, input
 print *
 
 if (n_seq + n_tokens_to_generate >= m%n_ctx) then

--- a/driver.f90
+++ b/driver.f90
@@ -175,7 +175,7 @@ call generate(output, n_tokens_to_generate, m, size(input), input, use_cache, &
 print *
 t2o = omp_get_wtime()
 call cpu_time(t2)
-print "(a,f8.3,a,f4.2,a)", "    done. Time:", t2o-t1o, "s (", (t2-t1)/(t2o-t1o), "x)"
+print "(a,f8.3,a,f8.2,a)", "    done. Time:", t2o-t1o, "s (", (t2-t1)/(t2o-t1o), "x)"
 print *
 print "(a)", "Output tokens:"
 print *, output

--- a/driver.f90
+++ b/driver.f90
@@ -231,7 +231,8 @@ else
 end if
 end function
 
-subroutine chat(inputs)
+subroutine chat(present_inputs, inputs)
+logical, intent(in) :: present_inputs
 type(string), optional, intent(in) :: inputs(:)
 type(model_t) :: m
 character(:), allocatable :: prompt, input, output
@@ -245,14 +246,14 @@ prompt = "Your name is fastGPT and you are an AI bot. The user will ask you &
 &fastGPT: Four." // LF // "&
 &User:"
 write(*,"(a)",advance="no") prompt
-if (present(inputs)) then
+if (present_inputs) then
     n_prompts = size(inputs)
 else
     n_prompts = 1024
 end if
 do i = 1, n_prompts
     write(*,"(a)",advance="no")  " "
-    if (present(inputs)) then
+    if (present_inputs) then
         input = inputs(i)%s
         write(*,"(a)") input
     else

--- a/driver.f90
+++ b/driver.f90
@@ -154,16 +154,16 @@ if (n_seq + n_tokens_to_generate >= m%n_ctx) then
     error stop
 end if
 
-!print "(a)", "Decoded input as text:"
+print "(a)", "Decoded input as text:"
 !print "(a)", decode(input, decoder_idx, decoder_txt, byte_decoder)
-!allocate(character(0) :: output_txt) ! Fix GFortran warning
-!output_txt = decode(input, m%decoder_idx, m%decoder_txt, byte_decoder)
-!print "(a)", output_txt
+allocate(character(0) :: output_txt) ! Fix GFortran warning
+output_txt = decode(input, m%decoder_idx, m%decoder_txt, byte_decoder)
+print *, output_txt
 print *
 
-!if (input_txt /= output_txt) then
-!    error stop "The decoded input text does not agree with the input text"
-!end if
+if (input_txt /= output_txt) then
+    error stop "The decoded input text does not agree with the input text"
+end if
 
 allocate(output(n_tokens_to_generate))
 print "(a)", "Running model..."

--- a/driver.f90
+++ b/driver.f90
@@ -154,16 +154,16 @@ if (n_seq + n_tokens_to_generate >= m%n_ctx) then
     error stop
 end if
 
-print "(a)", "Decoded input as text:"
+!print "(a)", "Decoded input as text:"
 !print "(a)", decode(input, decoder_idx, decoder_txt, byte_decoder)
-allocate(character(0) :: output_txt) ! Fix GFortran warning
-output_txt = decode(input, m%decoder_idx, m%decoder_txt, byte_decoder)
-print "(a)", output_txt
+!allocate(character(0) :: output_txt) ! Fix GFortran warning
+!output_txt = decode(input, m%decoder_idx, m%decoder_txt, byte_decoder)
+!print "(a)", output_txt
 print *
 
-if (input_txt /= output_txt) then
-    error stop "The decoded input text does not agree with the input text"
-end if
+!if (input_txt /= output_txt) then
+!    error stop "The decoded input text does not agree with the input text"
+!end if
 
 allocate(output(n_tokens_to_generate))
 print "(a)", "Running model..."

--- a/driver.f90
+++ b/driver.f90
@@ -174,7 +174,7 @@ allocate(output(n_tokens_to_generate))
 print "(a)", "Running model..."
 call cpu_time(t1)
 t1o = omp_get_wtime()
-use_cache = .true.
+use_cache = .false.
 call generate(output, n_tokens_to_generate, m, size(input), input, use_cache, &
     byte_decoder)
 print *

--- a/driver.f90
+++ b/driver.f90
@@ -183,11 +183,15 @@ call cpu_time(t2)
 print "(a,f8.3,a,f4.2,a)", "    done. Time:", t2o-t1o, "s (", (t2-t1)/(t2o-t1o), "x)"
 print *
 print "(a)", "Output tokens:"
-print "(1000(i6))", output
+print *, output
 output_txt = decode(output, m%decoder_idx, m%decoder_txt, byte_decoder)
 print *
 print "(a)", "Decoded output as text:"
 print "(a)", output_txt
+if (output(1) /= 703) error stop
+if (output(2) /= 484) error stop
+if (output(19) /= 1517) error stop
+if (output(20) /= 318) error stop
 end subroutine
 
 subroutine gpt2_driver3(input_txt, n_tokens_to_generate, stop_text, m, output_txt)

--- a/driver.f90
+++ b/driver.f90
@@ -147,11 +147,6 @@ print "(a)", "Input tokens:"
 !print "(1000(i6))", input
 print *, input
 print *
-if (n_seq /= 19) error stop
-if (input(1) /= 36235) error stop
-if (input(2) /= 39141) error stop
-if (input(18) /= 407) error stop
-if (input(19) /= 5967) error stop
 
 if (n_seq + n_tokens_to_generate >= m%n_ctx) then
     print *, "The maximum sequence length of the model was surpassed."
@@ -188,10 +183,6 @@ output_txt = decode(output, m%decoder_idx, m%decoder_txt, byte_decoder)
 print *
 print "(a)", "Decoded output as text:"
 print *, output_txt
-if (output(1) /= 703) error stop
-if (output(2) /= 484) error stop
-if (output(19) /= 1517) error stop
-if (output(20) /= 318) error stop
 end subroutine
 
 subroutine gpt2_driver3(input_txt, n_tokens_to_generate, stop_text, m, output_txt)

--- a/driver.f90
+++ b/driver.f90
@@ -184,10 +184,10 @@ print "(a,f8.3,a,f4.2,a)", "    done. Time:", t2o-t1o, "s (", (t2-t1)/(t2o-t1o),
 print *
 print "(a)", "Output tokens:"
 print *, output
-output_txt = decode(output, m%decoder_idx, m%decoder_txt, byte_decoder)
-print *
-print "(a)", "Decoded output as text:"
-print "(a)", output_txt
+!output_txt = decode(output, m%decoder_idx, m%decoder_txt, byte_decoder)
+!print *
+!print "(a)", "Decoded output as text:"
+!print "(a)", output_txt
 if (output(1) /= 703) error stop
 if (output(2) /= 484) error stop
 if (output(19) /= 1517) error stop

--- a/driver.f90
+++ b/driver.f90
@@ -175,7 +175,7 @@ print "(a)", "Running model..."
 call cpu_time(t1)
 t1o = omp_get_wtime()
 use_cache = .true.
-output = generate(n_tokens_to_generate, m, size(input), input, use_cache, &
+call generate(output, n_tokens_to_generate, m, size(input), input, use_cache, &
     byte_decoder)
 print *
 t2o = omp_get_wtime()
@@ -225,7 +225,7 @@ if (input_txt /= output_txt) then
     error stop "The decoded input text does not agree with the input text"
 end if
 use_cache = .true.
-output = generate(n_tokens_to_generate, m, size(input), input, use_cache, &
+call generate(output, n_tokens_to_generate, m, size(input), input, use_cache, &
     byte_decoder, stop_text)
 output_txt = decode(output, m%decoder_idx, m%decoder_txt, byte_decoder)
 end subroutine

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -169,7 +169,11 @@ else
 end if
 ! Perform attention over each head
 do l = 1, n_head
-    q = x2((l-1)*n_embd/n_head+1:l*n_embd/n_head,:)
+    do i = 1, n_seq_x
+    do j = 1, n_embd/n_head
+        q(j,i) = x2((l-1)*n_embd/n_head+j,i)
+    end do
+    end do
     do i = 1, n_seq
     do j = 1, n_embd/n_head
         k(j,i) = kv_cache((l-1)*n_embd/n_head+j,i,1)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -195,6 +195,10 @@ logical, intent(in) :: use_kv_cache
 real(sp) :: y(n_embd,n_seq_x)
 real(sp), intent(inout) :: kv_cache(n_embd,n_seq,2)
 real(sp) :: tln2_g(size(ln2_g)), tln2_b(size(ln2_b))
+real(sp) :: tmlp_fc_w(size(mlp_fc_w,1),size(mlp_fc_w,2)), &
+    tmlp_fc_b(size(mlp_fc_b)), &
+    tmlp_proj_w(size(mlp_proj_w,1),size(mlp_proj_w,2)), &
+    tmlp_proj_b(size(mlp_proj_b))
 call layer_norm(y, x, ln1_g, ln1_b, 1e-5_sp)
 x = x + mha(n_seq, n_seq_x, n_embd, y, &
     attn_w, attn_b, attn_proj_w, attn_proj_b, n_head, use_kv_cache, kv_cache)
@@ -205,7 +209,11 @@ call layer_norm(y, x, tln2_g, tln2_b, 1e-5_sp)
 !print *, "Out1:", y(1,1)
 !x = y
 !print *, "Out2:", x(1,1)
-call ffn(x, y, mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b)
+tmlp_fc_w = mlp_fc_w
+tmlp_fc_b = mlp_fc_b
+tmlp_proj_w = mlp_proj_w
+tmlp_proj_b = mlp_proj_b
+call ffn(x, y, tmlp_fc_w, tmlp_fc_b, tmlp_proj_w, tmlp_proj_b)
 end subroutine
 
 subroutine gpt2(y, n_vocab, n_ctx, n_seq, n_seq_x, n_embd, n_layer, n_head, input, &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -195,17 +195,17 @@ logical, intent(in) :: use_kv_cache
 real(sp) :: y(n_embd,n_seq_x)
 real(sp), intent(inout) :: kv_cache(n_embd,n_seq,2)
 real(sp) :: tln2_g(size(ln2_g)), tln2_b(size(ln2_b))
-!call layer_norm(y, x, ln1_g, ln1_b, 1e-5_sp)
-!x = x + mha(n_seq, n_seq_x, n_embd, y, &
-!    attn_w, attn_b, attn_proj_w, attn_proj_b, n_head, use_kv_cache, kv_cache)
+call layer_norm(y, x, ln1_g, ln1_b, 1e-5_sp)
+x = x + mha(n_seq, n_seq_x, n_embd, y, &
+    attn_w, attn_b, attn_proj_w, attn_proj_b, n_head, use_kv_cache, kv_cache)
 tln2_g = ln2_g
 tln2_b = ln2_b
-print *, "In: ", x(1,1), ln2_g(1), ln2_g(size(ln2_g)), ln2_b(1), ln2_b(size(ln2_b))
+!print *, "In: ", x(1,1), ln2_g(1), ln2_g(size(ln2_g)), ln2_b(1), ln2_b(size(ln2_b))
 call layer_norm(y, x, tln2_g, tln2_b, 1e-5_sp)
-print *, "Out1:", y(1,1)
-x = y
-print *, "Out2:", x(1,1)
-!call ffn(x, y, mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b)
+!print *, "Out1:", y(1,1)
+!x = y
+!print *, "Out2:", x(1,1)
+call ffn(x, y, mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b)
 end subroutine
 
 subroutine gpt2(y, n_vocab, n_ctx, n_seq, n_seq_x, n_embd, n_layer, n_head, input, &
@@ -251,7 +251,6 @@ do i = 1, n_layer
         n_head, use_kv_cache, kv_cache(:,:,:,i))
 !    print *, x(1,1)
 end do
-stop "OK"
 call layer_norm(yy, x, lnf_g, lnf_b, 1e-5)
 x = yy
 !y = matmul(transpose(wte), x)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -118,10 +118,15 @@ integer, intent(in) :: n_embd_head, n_seq, n_seq_x
 real(sp), intent(in) :: q(n_embd_head,n_seq_x), k(n_embd_head,n_seq), v(n_embd_head,n_seq), mask(n_seq,n_seq_x)
 real(sp), intent(out) :: y(n_embd_head,n_seq_x)
 real(sp) :: tmp(n_seq,n_seq_x)
+integer :: i, j
 !tmp = matmul(transpose(k), q)
 !call matmul_2d(transpose(k), q, tmp)
 call matmul_2d_t(k, q, tmp)
-tmp = tmp / sqrt(real(n_embd_head,sp)) + mask
+do i = 1, n_seq_x
+do j = 1, n_seq
+    tmp(j,i) = tmp(j,i) / sqrt(real(n_embd_head,sp)) + mask(j,i)
+end do
+end do
 tmp = softmax(tmp)
 call matmul_2d(v, tmp, y)
 end subroutine

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -152,19 +152,18 @@ else
     end do
 end if
 x2 = linear(x, attn_w, attn_b)
-associate ( &
-        q => x2((1-1)*n_embd+1:1*n_embd,:), &
-        k => x2((2-1)*n_embd+1:2*n_embd,:), &
-        v => x2((3-1)*n_embd+1:3*n_embd,:)  &
-    )
-    if (use_kv_cache) then
-        kv_cache(:,n_seq,1) = k(:,1)
-        kv_cache(:,n_seq,2) = v(:,1)
-    else
-        kv_cache(:,:,1) = k
-        kv_cache(:,:,2) = v
-    end if
-end associate
+if (use_kv_cache) then
+    error stop
+    !kv_cache(:,n_seq,1) = k(:,1)
+    !kv_cache(:,n_seq,2) = v(:,1)
+else
+    do i = 1, n_seq
+    do j = 1, n_embd
+        kv_cache(j,i,1) = x2((2-1)*n_embd+j,i)
+        kv_cache(j,i,2) = x2((3-1)*n_embd+j,i)
+    end do
+    end do
+end if
 associate ( &
         q => x2((1-1)*n_embd+1:1*n_embd,:), &
         k => kv_cache(:,:,1), &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -153,9 +153,10 @@ else
 end if
 x2 = linear(x, attn_w, attn_b)
 if (use_kv_cache) then
-    error stop
-    !kv_cache(:,n_seq,1) = k(:,1)
-    !kv_cache(:,n_seq,2) = v(:,1)
+    do j = 1, n_embd
+        kv_cache(j,n_seq,1) = x2((2-1)*n_embd+j,1)
+        kv_cache(j,n_seq,2) = x2((3-1)*n_embd+j,1)
+    end do
 else
     do i = 1, n_seq
     do j = 1, n_embd

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -221,7 +221,9 @@ else
         end do
     end do
 end if
+print *, "It fails below:"
 do i = 1, n_layer
+    print *, i ! Never gets printed
     x = transformer_block(n_seq, n_seq_x, n_embd, x, &
         mlp_fc_w(:,:,i), mlp_fc_b(:,i), &
         mlp_proj_w(:,:,i), mlp_proj_b(:,i), &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -52,10 +52,16 @@ end function
 function softmax(x) result(y)
 real(sp), intent(in) :: x(:,:)
 real(sp) :: y(size(x,1),size(x,2))
-integer :: i
+integer :: i,j
+real(sp) :: s
 do i = 1, size(x,2)
-    y(:,i) = exp(x(:,i) - maxval(x(:,i)))
-    y(:,i) = y(:,i) / sum(y(:,i))
+    do j = 1, size(x,1)
+        y(j,i) = exp(x(j,i) - maxval(x(:,i)))
+    end do
+    s = sum(y(:,i))
+    do j = 1, size(x,1)
+        y(j,i) = y(j,i) / s
+    end do
 end do
 end function
 

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -238,17 +238,17 @@ x = layer_norm(x, lnf_g, lnf_b, 1e-5)
 call matmul_2d_t(wte, x, y)
 end subroutine
 
-function generate(n_tokens_to_generate, m, &
+subroutine generate(output, n_tokens_to_generate, m, &
         n_seq, input, &
         use_cache, &
-        byte_decoder, stop_text) result(output)
+        byte_decoder, stop_text)
 integer, intent(in) :: n_seq, n_tokens_to_generate
 type(model_t), intent(in) :: m
 integer, intent(in) :: input(n_seq)
 logical, intent(in) :: use_cache
 integer, intent(in) :: byte_decoder(:)
 character(*), intent(in), optional :: stop_text ! Stop if you see this text
-integer, allocatable :: output(:)
+integer, allocatable, intent(out) :: output(:)
 real(sp), allocatable :: logits(:,:)
 integer :: i
 integer :: n_seq2, n_seq_x
@@ -295,6 +295,6 @@ do i = 1, n_tokens_to_generate
     deallocate(logits)
 end do
 output = input2(n_seq+1:)
-end function
+end subroutine
 
 end module

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -137,6 +137,7 @@ real(sp), intent(out) :: y(n_embd,n_seq_x)
 real(sp) :: causal_mask(n_seq,n_seq_x)
 real(sp) :: x2(3*n_embd,n_seq_x)
 real(sp) :: q(n_embd/n_head,n_seq_x), k(n_embd/n_head,n_seq), v(n_embd/n_head,n_seq)
+real(sp) :: yy(n_embd/n_head,n_seq_x)
 integer :: i, j
 ! Mask
 if (use_kv_cache) then
@@ -171,8 +172,8 @@ do i = 1, n_head
     q = x2((i-1)*n_embd/n_head+1:i*n_embd/n_head,:)
     k = kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,1)
     v = kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,2)
-    call attention(y((i-1)*n_embd/n_head+1:i*n_embd/n_head,:), &
-        n_embd/n_head, n_seq, n_seq_x, q, k, v, causal_mask)
+    call attention(yy, n_embd/n_head, n_seq, n_seq_x, q, k, v, causal_mask)
+    y((i-1)*n_embd/n_head+1:i*n_embd/n_head,:) = yy
 end do
 ! Out projection
 y = linear(y, proj_w, proj_b)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -234,6 +234,7 @@ end do
 x = layer_norm(x, lnf_g, lnf_b, 1e-5)
 !y = matmul(transpose(wte), x)
 call matmul_2d_t(wte, x, y)
+stop "OK"
 end function
 
 function generate(n_tokens_to_generate, m, &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -58,7 +58,10 @@ do i = 1, size(x,2)
     do j = 1, size(x,1)
         y(j,i) = exp(x(j,i) - maxval(x(:,i)))
     end do
-    s = sum(y(:,i))
+    s = 0
+    do j = 1, size(x,1)
+        s = s + y(j,i)
+    end do
     do j = 1, size(x,1)
         y(j,i) = y(j,i) / s
     end do

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -165,18 +165,14 @@ else
     end do
     end do
 end if
-associate ( &
-        q => x2((1-1)*n_embd+1:1*n_embd,:), &
-        k => kv_cache(:,:,1), &
-        v => kv_cache(:,:,2)  &
-    )
+associate ( q => x2((1-1)*n_embd+1:1*n_embd,:) )
     ! Perform attention over each head
     do i = 1, n_head
         y((i-1)*n_embd/n_head+1:i*n_embd/n_head,:) = attention( &
             n_embd/n_head, n_seq, n_seq_x, &
             q((i-1)*n_embd/n_head+1:i*n_embd/n_head,:), &
-            k((i-1)*n_embd/n_head+1:i*n_embd/n_head,:), &
-            v((i-1)*n_embd/n_head+1:i*n_embd/n_head,:), &
+            kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,1), &
+            kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,2), &
             causal_mask)
     end do
 end associate

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -181,7 +181,11 @@ do l = 1, n_head
     end do
     end do
     call attention(yy, n_embd/n_head, n_seq, n_seq_x, q, k, v, causal_mask)
-    y((l-1)*n_embd/n_head+1:l*n_embd/n_head,:) = yy
+    do i = 1, n_seq_x
+    do j = 1, n_embd/n_head
+        y((l-1)*n_embd/n_head+j,i) = yy(j,i)
+    end do
+    end do
 end do
 ! Out projection
 y = linear(y, proj_w, proj_b)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -238,7 +238,9 @@ else
     end do
 end if
 !print *, "It fails below:"
-do i = 1, n_layer
+do j = 1, n_layer
+    i = j
+    !i = 1
 !    print *, i ! Never gets printed
     call transformer_block(n_seq, n_seq_x, n_embd, x, &
         mlp_fc_w(:,:,i), mlp_fc_b(:,i), &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -263,7 +263,9 @@ real(sp) :: yy(n_embd,n_seq_x)
 integer :: i, j
 if (use_kv_cache) then
     i = n_seq
-    x(:,1) = wte(:,input(i)+1) + wpe(:,i)
+    do j = 1, n_embd
+        x(j,1) = wte(j,input(i)+1) + wpe(j,i)
+    end do
 else
     do i = 1, n_seq
         do j = 1, n_embd
@@ -308,6 +310,7 @@ integer :: next_id
 integer :: input2(size(input)+n_tokens_to_generate)
 logical :: use_kv_cache
 real(sp) :: kv_cache(m%n_embd,n_seq+n_tokens_to_generate,2,m%n_layer)
+real(sp), allocatable :: kv_cache2(:,:,:,:)
 character(:), allocatable :: output_txt, last_token
 if (present(stop_text)) then
     output_txt = ""
@@ -326,13 +329,18 @@ do i = 1, n_tokens_to_generate
         n_seq_x = n_seq2
     end if
     allocate(logits(m%n_vocab, n_seq_x))
+    allocate(kv_cache2(m%n_embd,n_seq+n_tokens_to_generate,2,m%n_layer))
+    kv_cache2 = kv_cache(:,:n_seq2,:,:)
     call gpt2(logits, m%n_vocab, m%n_ctx, n_seq2, n_seq_x, m%n_embd, m%n_layer, &
             m%n_head, &
             input2(:n_seq2), &
             m%wte, m%wpe, &
             m%mlp_fc_w, m%mlp_fc_b, m%mlp_proj_w, m%mlp_proj_b, &
             m%attn_w, m%attn_b, m%attn_proj_w, m%attn_proj_b, &
-            m%ln1_g, m%ln1_b, m%ln2_g, m%ln2_b, m%lnf_g, m%lnf_b, use_kv_cache, kv_cache(:,:n_seq2,:,:))
+            m%ln1_g, m%ln1_b, m%ln2_g, m%ln2_b, m%lnf_g, m%lnf_b, use_kv_cache,&
+            kv_cache2)
+    kv_cache(:,:n_seq2,:,:) = kv_cache2
+    deallocate(kv_cache2)
     next_id = maxloc(logits(:,n_seq_x), dim=1)-1
     input2(n_seq2+1) = next_id
     !last_token = decode([next_id], m%decoder_idx, &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -210,13 +210,15 @@ logical, intent(in) :: use_kv_cache
 real(sp), intent(inout) :: kv_cache(n_embd,n_seq,2,n_layer)
 real(sp) :: y(n_vocab,n_seq_x)
 real(sp) :: x(n_embd,n_seq_x)
-integer :: i
+integer :: i, j
 if (use_kv_cache) then
     i = n_seq
     x(:,1) = wte(:,input(i)+1) + wpe(:,i)
 else
     do i = 1, n_seq
-        x(:,i) = wte(:,input(i)+1) + wpe(:,i)
+        do j = 1, n_embd
+            x(j,i) = wte(j,input(i)+1) + wpe(j,i)
+        end do
     end do
 end if
 do i = 1, n_layer

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -70,7 +70,10 @@ do i = 1, size(x,2)
         xi(j) = x(j,i)
     end do
     mean(i) = sum(xi) / size(x,1)
-    variance(i) = sum((xi - mean(i))**2) / size(x,1)
+    do j = 1, size(x,1)
+        xi(j) = (xi(j) - mean(i))**2
+    end do
+    variance(i) = sum(xi) / size(x,1)
 end do
 !do i = 1, size(x,1)
 !    y(i,:) = (x(i,:) - mean(:)) / sqrt(variance(:) + eps)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -165,17 +165,15 @@ else
     end do
     end do
 end if
-associate ( q => x2((1-1)*n_embd+1:1*n_embd,:) )
-    ! Perform attention over each head
-    do i = 1, n_head
-        y((i-1)*n_embd/n_head+1:i*n_embd/n_head,:) = attention( &
-            n_embd/n_head, n_seq, n_seq_x, &
-            q((i-1)*n_embd/n_head+1:i*n_embd/n_head,:), &
-            kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,1), &
-            kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,2), &
-            causal_mask)
-    end do
-end associate
+! Perform attention over each head
+do i = 1, n_head
+    y((i-1)*n_embd/n_head+1:i*n_embd/n_head,:) = attention( &
+        n_embd/n_head, n_seq, n_seq_x, &
+        x2((i-1)*n_embd/n_head+1:i*n_embd/n_head,:), &
+        kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,1), &
+        kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,2), &
+        causal_mask)
+end do
 ! Out projection
 y = linear(y, proj_w, proj_b)
 end subroutine

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -304,7 +304,7 @@ integer, intent(in) :: byte_decoder(:)
 character(*), intent(in), optional :: stop_text ! Stop if you see this text
 integer, intent(out) :: output(:)
 real(sp), allocatable :: logits(:,:)
-integer :: i
+integer :: i, i1, i2, i3, i4
 integer :: n_seq2, n_seq_x
 integer :: next_id
 integer :: input2(size(input)+n_tokens_to_generate)
@@ -330,7 +330,15 @@ do i = 1, n_tokens_to_generate
     end if
     allocate(logits(m%n_vocab, n_seq_x))
     allocate(kv_cache2(m%n_embd,n_seq2,2,m%n_layer))
-    kv_cache2(:,:,:,:) = kv_cache(:,:n_seq2,:,:)
+    do i4 = 1, m%n_layer
+    do i3 = 1, 2
+    do i2 = 1, n_seq2
+    do i1 = 1, m%n_embd
+        kv_cache2(i1,i2,i3,i4) = kv_cache(i1,i2,i3,i4)
+    end do
+    end do
+    end do
+    end do
     call gpt2(logits, m%n_vocab, m%n_ctx, n_seq2, n_seq_x, m%n_embd, m%n_layer, &
             m%n_head, &
             input2(:n_seq2), &
@@ -339,7 +347,15 @@ do i = 1, n_tokens_to_generate
             m%attn_w, m%attn_b, m%attn_proj_w, m%attn_proj_b, &
             m%ln1_g, m%ln1_b, m%ln2_g, m%ln2_b, m%lnf_g, m%lnf_b, use_kv_cache,&
             kv_cache2)
-    kv_cache(:,:n_seq2,:,:) = kv_cache2(:,:,:,:)
+    do i4 = 1, m%n_layer
+    do i3 = 1, 2
+    do i2 = 1, n_seq2
+    do i1 = 1, m%n_embd
+        kv_cache(i1,i2,i3,i4) = kv_cache2(i1,i2,i3,i4)
+    end do
+    end do
+    end do
+    end do
     deallocate(kv_cache2)
     next_id = maxloc(logits(:,n_seq_x), dim=1)-1
     input2(n_seq2+1) = next_id

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -359,9 +359,9 @@ do i = 1, n_tokens_to_generate
     deallocate(kv_cache2)
     next_id = maxloc(logits(:,n_seq_x), dim=1)-1
     input2(n_seq2+1) = next_id
-    !last_token = decode([next_id], m%decoder_idx, &
-    !    m%decoder_txt, byte_decoder)
-    !write(*, fmt="(a)", advance="no") last_token
+    last_token = decode([next_id], m%decoder_idx, &
+        m%decoder_txt, byte_decoder)
+    write(*, fmt="(a)", advance="no") last_token
     if (present(stop_text)) then
         output_txt = output_txt // last_token
         if (output_txt(len(output_txt)-len(stop_text)+1:len(output_txt)) == stop_text) then

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -59,9 +59,9 @@ do i = 1, size(x,2)
 end do
 end function
 
-function layer_norm(x, g, b, eps) result(y)
+subroutine layer_norm(y, x, g, b, eps)
 real(sp), intent(in) :: x(:,:), g(:), b(:), eps
-real(sp) :: y(size(x,1),size(x,2))
+real(sp), intent(out) :: y(size(x,1),size(x,2))
 real(sp) :: mean(size(x,2)), variance(size(x,2))
 real(sp) :: xi(size(x,1))
 integer :: i, j
@@ -85,7 +85,7 @@ do i = 1, size(x,2)
         y(j,i) = g(j) * y(j,i) + b(j)
     end do
 end do
-end function
+end subroutine
 
 function linear(x, w, b) result(y)
 real(sp), intent(in) :: x(:,:), w(:,:), b(:)
@@ -220,6 +220,7 @@ logical, intent(in) :: use_kv_cache
 real(sp), intent(inout) :: kv_cache(n_embd,n_seq,2,n_layer)
 real(sp), intent(out) :: y(n_vocab,n_seq_x)
 real(sp) :: x(n_embd,n_seq_x)
+real(sp) :: yy(n_embd,n_seq_x)
 integer :: i, j
 if (use_kv_cache) then
     i = n_seq
@@ -241,7 +242,8 @@ do i = 1, n_layer
         ln1_g(:,i), ln1_b(:,i), ln2_g(:,i), ln2_b(:,i), &
         n_head, use_kv_cache, kv_cache(:,:,:,i))
 end do
-x = layer_norm(x, lnf_g, lnf_b, 1e-5)
+call layer_norm(yy, x, lnf_g, lnf_b, 1e-5)
+x = yy
 !y = matmul(transpose(wte), x)
 call matmul_2d_t(wte, x, y)
 end subroutine

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -113,16 +113,16 @@ yy = linear(a, proj_w, proj_b)
 y = y + yy
 end subroutine
 
-function attention(n_embd_head,n_seq,n_seq_x, q, k, v, mask) result(y)
+subroutine attention(y, n_embd_head,n_seq,n_seq_x, q, k, v, mask)
 integer, intent(in) :: n_embd_head, n_seq, n_seq_x
 real(sp), intent(in) :: q(n_embd_head,n_seq_x), k(n_embd_head,n_seq), v(n_embd_head,n_seq), mask(n_seq,n_seq_x)
-real(sp) :: y(n_embd_head,n_seq_x)
+real(sp), intent(out) :: y(n_embd_head,n_seq_x)
 real(sp) :: tmp(n_seq,n_seq_x)
 !tmp = matmul(transpose(k), q)
 !call matmul_2d(transpose(k), q, tmp)
 call matmul_2d_t(k, q, tmp)
 call matmul_2d(v, softmax(tmp / sqrt(real(n_embd_head,sp)) + mask), y)
-end function
+end subroutine
 
 subroutine mha(y, n_seq, n_seq_x, n_embd, x, attn_w, attn_b, proj_w, proj_b, n_head, &
             use_kv_cache, kv_cache)
@@ -167,7 +167,7 @@ else
 end if
 ! Perform attention over each head
 do i = 1, n_head
-    y((i-1)*n_embd/n_head+1:i*n_embd/n_head,:) = attention( &
+    call attention(y((i-1)*n_embd/n_head+1:i*n_embd/n_head,:), &
         n_embd/n_head, n_seq, n_seq_x, &
         x2((i-1)*n_embd/n_head+1:i*n_embd/n_head,:), &
         kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,1), &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -329,8 +329,8 @@ do i = 1, n_tokens_to_generate
         n_seq_x = n_seq2
     end if
     allocate(logits(m%n_vocab, n_seq_x))
-    allocate(kv_cache2(m%n_embd,n_seq+n_tokens_to_generate,2,m%n_layer))
-    kv_cache2 = kv_cache(:,:n_seq2,:,:)
+    allocate(kv_cache2(m%n_embd,n_seq2,2,m%n_layer))
+    kv_cache2(:,:,:,:) = kv_cache(:,:n_seq2,:,:)
     call gpt2(logits, m%n_vocab, m%n_ctx, n_seq2, n_seq_x, m%n_embd, m%n_layer, &
             m%n_head, &
             input2(:n_seq2), &
@@ -339,7 +339,7 @@ do i = 1, n_tokens_to_generate
             m%attn_w, m%attn_b, m%attn_proj_w, m%attn_proj_b, &
             m%ln1_g, m%ln1_b, m%ln2_g, m%ln2_b, m%lnf_g, m%lnf_b, use_kv_cache,&
             kv_cache2)
-    kv_cache(:,:n_seq2,:,:) = kv_cache2
+    kv_cache(:,:n_seq2,:,:) = kv_cache2(:,:,:,:)
     deallocate(kv_cache2)
     next_id = maxloc(logits(:,n_seq_x), dim=1)-1
     input2(n_seq2+1) = next_id

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -55,8 +55,12 @@ real(sp) :: y(size(x,1),size(x,2))
 integer :: i,j
 real(sp) :: s
 do i = 1, size(x,2)
+    s = -1e10
     do j = 1, size(x,1)
-        y(j,i) = exp(x(j,i) - maxval(x(:,i)))
+        if (x(j,i) > s) s = x(j,i)
+    end do
+    do j = 1, size(x,1)
+        y(j,i) = exp(x(j,i) - s)
     end do
     s = 0
     do j = 1, size(x,1)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -90,21 +90,27 @@ end subroutine
 function linear(x, w, b) result(y)
 real(sp), intent(in) :: x(:,:), w(:,:), b(:)
 real(sp) :: y(size(b,1),size(x,2))
-integer :: i
+integer :: i, j
 !y = matmul(w, x) + spread(b, 2, size(x,2))
 !y = matmul(w, x)
 call matmul_2d(w, x, y)
 do i = 1, size(y,2)
-    y(:,i) = y(:,i) + b(:)
+    do j = 1, size(y,1)
+        y(j,i) = y(j,i) + b(j)
+    end do
 end do
 end function
 
 subroutine ffn(y, x, fc_w, fc_b, proj_w, proj_b)
 real(sp), intent(in) :: x(:,:), fc_w(:,:), fc_b(:), proj_w(:,:), proj_b(:)
 real(sp), intent(inout) :: y(size(x,1),size(x,2))
-!real(sp) :: a(4*size(x,1),size(x,2))
-!a = gelu(linear(x, fc_w, fc_b))
-y = y + linear(gelu(linear(x, fc_w, fc_b)), proj_w, proj_b)
+real(sp) :: yy(size(x,1),size(x,2))
+real(sp) :: a(4*size(x,1),size(x,2))
+real(sp) :: aa(4*size(x,1),size(x,2))
+aa = linear(x, fc_w, fc_b)
+a = gelu(aa)
+yy = linear(a, proj_w, proj_b)
+y = y + yy
 end subroutine
 
 function attention(n_embd_head,n_seq,n_seq_x, q, k, v, mask) result(y)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -194,15 +194,18 @@ integer, intent(in) :: n_seq, n_seq_x, n_embd
 logical, intent(in) :: use_kv_cache
 real(sp) :: y(n_embd,n_seq_x)
 real(sp), intent(inout) :: kv_cache(n_embd,n_seq,2)
-call layer_norm(y, x, ln1_g, ln1_b, 1e-5_sp)
-x = x + mha(n_seq, n_seq_x, n_embd, y, &
-    attn_w, attn_b, attn_proj_w, attn_proj_b, n_head, use_kv_cache, kv_cache)
-!print *, "In: ", x(1,1), ln2_g(1), ln2_g(size(ln2_g)), ln2_b(1), ln2_b(size(ln2_b))
-call layer_norm(y, x, ln2_g, ln2_b, 1e-5_sp)
-!print *, "Out1:", y(1,1)
-!x = y
-!print *, "Out2:", x(1,1)
-call ffn(x, y, mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b)
+real(sp) :: tln2_g(size(ln2_g)), tln2_b(size(ln2_b))
+!call layer_norm(y, x, ln1_g, ln1_b, 1e-5_sp)
+!x = x + mha(n_seq, n_seq_x, n_embd, y, &
+!    attn_w, attn_b, attn_proj_w, attn_proj_b, n_head, use_kv_cache, kv_cache)
+tln2_g = ln2_g
+tln2_b = ln2_b
+print *, "In: ", x(1,1), ln2_g(1), ln2_g(size(ln2_g)), ln2_b(1), ln2_b(size(ln2_b))
+call layer_norm(y, x, tln2_g, tln2_b, 1e-5_sp)
+print *, "Out1:", y(1,1)
+x = y
+print *, "Out2:", x(1,1)
+!call ffn(x, y, mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b)
 end subroutine
 
 subroutine gpt2(y, n_vocab, n_ctx, n_seq, n_seq_x, n_embd, n_layer, n_head, input, &
@@ -248,7 +251,7 @@ do i = 1, n_layer
         n_head, use_kv_cache, kv_cache(:,:,:,i))
 !    print *, x(1,1)
 end do
-!stop "OK"
+stop "OK"
 call layer_norm(yy, x, lnf_g, lnf_b, 1e-5)
 x = yy
 !y = matmul(transpose(wte), x)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -170,8 +170,12 @@ end if
 ! Perform attention over each head
 do l = 1, n_head
     q = x2((l-1)*n_embd/n_head+1:l*n_embd/n_head,:)
-    k = kv_cache((l-1)*n_embd/n_head+1:l*n_embd/n_head,:,1)
-    v = kv_cache((l-1)*n_embd/n_head+1:l*n_embd/n_head,:,2)
+    do i = 1, n_seq
+    do j = 1, n_embd/n_head
+        k(j,i) = kv_cache((l-1)*n_embd/n_head+j,i,1)
+        v(j,i) = kv_cache((l-1)*n_embd/n_head+j,i,2)
+    end do
+    end do
     call attention(yy, n_embd/n_head, n_seq, n_seq_x, q, k, v, causal_mask)
     y((l-1)*n_embd/n_head+1:l*n_embd/n_head,:) = yy
 end do

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -194,9 +194,14 @@ integer, intent(in) :: n_seq, n_seq_x, n_embd
 logical, intent(in) :: use_kv_cache
 real(sp) :: y(n_embd,n_seq_x)
 real(sp), intent(inout) :: kv_cache(n_embd,n_seq,2)
-x = x + mha(n_seq, n_seq_x, n_embd, layer_norm(x, ln1_g, ln1_b, 1e-5_sp), &
+call layer_norm(y, x, ln1_g, ln1_b, 1e-5_sp)
+x = x + mha(n_seq, n_seq_x, n_embd, y, &
     attn_w, attn_b, attn_proj_w, attn_proj_b, n_head, use_kv_cache, kv_cache)
-y = layer_norm(x, ln2_g, ln2_b, 1e-5_sp)
+!print *, "In: ", x(1,1), ln2_g(1), ln2_g(size(ln2_g)), ln2_b(1), ln2_b(size(ln2_b))
+call layer_norm(y, x, ln2_g, ln2_b, 1e-5_sp)
+!print *, "Out1:", y(1,1)
+!x = y
+!print *, "Out2:", x(1,1)
 call ffn(x, y, mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b)
 end subroutine
 
@@ -241,7 +246,9 @@ do i = 1, n_layer
         attn_w(:,:,i), attn_b(:,i), attn_proj_w(:,:,i), attn_proj_b(:,i), &
         ln1_g(:,i), ln1_b(:,i), ln2_g(:,i), ln2_b(:,i), &
         n_head, use_kv_cache, kv_cache(:,:,:,i))
+!    print *, x(1,1)
 end do
+!stop "OK"
 call layer_norm(yy, x, lnf_g, lnf_b, 1e-5)
 x = yy
 !y = matmul(transpose(wte), x)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -194,26 +194,15 @@ integer, intent(in) :: n_seq, n_seq_x, n_embd
 logical, intent(in) :: use_kv_cache
 real(sp) :: y(n_embd,n_seq_x)
 real(sp), intent(inout) :: kv_cache(n_embd,n_seq,2)
-real(sp) :: tln2_g(size(ln2_g)), tln2_b(size(ln2_b))
-real(sp) :: tmlp_fc_w(size(mlp_fc_w,1),size(mlp_fc_w,2)), &
-    tmlp_fc_b(size(mlp_fc_b)), &
-    tmlp_proj_w(size(mlp_proj_w,1),size(mlp_proj_w,2)), &
-    tmlp_proj_b(size(mlp_proj_b))
 call layer_norm(y, x, ln1_g, ln1_b, 1e-5_sp)
 x = x + mha(n_seq, n_seq_x, n_embd, y, &
     attn_w, attn_b, attn_proj_w, attn_proj_b, n_head, use_kv_cache, kv_cache)
-tln2_g = ln2_g
-tln2_b = ln2_b
 !print *, "In: ", x(1,1), ln2_g(1), ln2_g(size(ln2_g)), ln2_b(1), ln2_b(size(ln2_b))
-call layer_norm(y, x, tln2_g, tln2_b, 1e-5_sp)
+call layer_norm(y, x, ln2_g, ln2_b, 1e-5_sp)
 !print *, "Out1:", y(1,1)
 !x = y
 !print *, "Out2:", x(1,1)
-tmlp_fc_w = mlp_fc_w
-tmlp_fc_b = mlp_fc_b
-tmlp_proj_w = mlp_proj_w
-tmlp_proj_b = mlp_proj_b
-call ffn(x, y, tmlp_fc_w, tmlp_fc_b, tmlp_proj_w, tmlp_proj_b)
+call ffn(x, y, mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b)
 end subroutine
 
 subroutine gpt2(y, n_vocab, n_ctx, n_seq, n_seq_x, n_embd, n_layer, n_head, input, &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -121,7 +121,9 @@ real(sp) :: tmp(n_seq,n_seq_x)
 !tmp = matmul(transpose(k), q)
 !call matmul_2d(transpose(k), q, tmp)
 call matmul_2d_t(k, q, tmp)
-call matmul_2d(v, softmax(tmp / sqrt(real(n_embd_head,sp)) + mask), y)
+tmp = tmp / sqrt(real(n_embd_head,sp)) + mask
+tmp = softmax(tmp)
+call matmul_2d(v, tmp, y)
 end subroutine
 
 subroutine mha(y, n_seq, n_seq_x, n_embd, x, attn_w, attn_b, proj_w, proj_b, n_head, &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -21,7 +21,7 @@ type :: model_t
         ln2_b(:,:), ln2_g(:,:), &
         lnf_b(:), lnf_g(:)
     integer, allocatable :: decoder_idx(:), vocab_idx(:), byte_encoder(:)
-    character, allocatable :: decoder_txt(:), vocab_txt(:)
+    integer(1), allocatable :: decoder_txt(:), vocab_txt(:)
     integer :: model_file_version
 end type
 

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -223,9 +223,9 @@ else
         end do
     end do
 end if
-print *, "It fails below:"
+!print *, "It fails below:"
 do i = 1, n_layer
-    print *, i ! Never gets printed
+!    print *, i ! Never gets printed
     call transformer_block(n_seq, n_seq_x, n_embd, x, &
         mlp_fc_w(:,:,i), mlp_fc_b(:,i), &
         mlp_proj_w(:,:,i), mlp_proj_b(:,i), &
@@ -236,7 +236,7 @@ end do
 x = layer_norm(x, lnf_g, lnf_b, 1e-5)
 !y = matmul(transpose(wte), x)
 call matmul_2d_t(wte, x, y)
-stop "OK"
+!stop "OK"
 end subroutine
 
 function generate(n_tokens_to_generate, m, &

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -302,7 +302,7 @@ integer, intent(in) :: input(n_seq)
 logical, intent(in) :: use_cache
 integer, intent(in) :: byte_decoder(:)
 character(*), intent(in), optional :: stop_text ! Stop if you see this text
-integer, intent(out) :: output(:)
+integer, allocatable, intent(out) :: output(:)
 real(sp), allocatable :: logits(:,:)
 integer :: i, i1, i2, i3, i4
 integer :: n_seq2, n_seq_x
@@ -370,7 +370,9 @@ do i = 1, n_tokens_to_generate
     end if
     deallocate(logits)
 end do
-do i = 1, n_tokens_to_generate
+! output = input2(n_seq+1:n_seq2+1)
+allocate(output(n_seq2 - n_seq + 1))
+do i = 1, n_seq2 - n_seq + 1
     output(i) = input2(n_seq+i)
 end do
 end subroutine

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -63,10 +63,14 @@ function layer_norm(x, g, b, eps) result(y)
 real(sp), intent(in) :: x(:,:), g(:), b(:), eps
 real(sp) :: y(size(x,1),size(x,2))
 real(sp) :: mean(size(x,2)), variance(size(x,2))
+real(sp) :: xi(size(x,1))
 integer :: i, j
 do i = 1, size(x,2)
-    mean(i) = sum(x(:,i)) / size(x,1)
-    variance(i) = sum((x(:,i) - mean(i))**2) / size(x,1)
+    do j = 1, size(x,1)
+        xi(j) = x(j,i)
+    end do
+    mean(i) = sum(xi) / size(x,1)
+    variance(i) = sum((xi - mean(i))**2) / size(x,1)
 end do
 !do i = 1, size(x,1)
 !    y(i,:) = (x(i,:) - mean(:)) / sqrt(variance(:) + eps)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -63,7 +63,7 @@ function layer_norm(x, g, b, eps) result(y)
 real(sp), intent(in) :: x(:,:), g(:), b(:), eps
 real(sp) :: y(size(x,1),size(x,2))
 real(sp) :: mean(size(x,2)), variance(size(x,2))
-integer :: i
+integer :: i, j
 do i = 1, size(x,2)
     mean(i) = sum(x(:,i)) / size(x,1)
     variance(i) = sum((x(:,i) - mean(i))**2) / size(x,1)
@@ -73,8 +73,10 @@ end do
 !    y(i,:) = g(i) * y(i,:) + b(i)
 !end do
 do i = 1, size(x,2)
-    y(:,i) = (x(:,i) - mean(i)) / sqrt(variance(i) + eps)
-    y(:,i) = g(:) * y(:,i) + b(:)
+    do j = 1, size(x,1)
+        y(j,i) = (x(j,i) - mean(i)) / sqrt(variance(i) + eps)
+        y(j,i) = g(j) * y(j,i) + b(j)
+    end do
 end do
 end function
 

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -224,12 +224,12 @@ end if
 print *, "It fails below:"
 do i = 1, n_layer
     print *, i ! Never gets printed
-    x = transformer_block(n_seq, n_seq_x, n_embd, x, &
-        mlp_fc_w(:,:,i), mlp_fc_b(:,i), &
-        mlp_proj_w(:,:,i), mlp_proj_b(:,i), &
-        attn_w(:,:,i), attn_b(:,i), attn_proj_w(:,:,i), attn_proj_b(:,i), &
-        ln1_g(:,i), ln1_b(:,i), ln2_g(:,i), ln2_b(:,i), &
-        n_head, use_kv_cache, kv_cache(:,:,:,i))
+!    x = transformer_block(n_seq, n_seq_x, n_embd, x, &
+!        mlp_fc_w(:,:,i), mlp_fc_b(:,i), &
+!        mlp_proj_w(:,:,i), mlp_proj_b(:,i), &
+!        attn_w(:,:,i), attn_b(:,i), attn_proj_w(:,:,i), attn_proj_b(:,i), &
+!        ln1_g(:,i), ln1_b(:,i), ln2_g(:,i), ln2_b(:,i), &
+!        n_head, use_kv_cache, kv_cache(:,:,:,i))
 end do
 x = layer_norm(x, lnf_g, lnf_b, 1e-5)
 !y = matmul(transpose(wte), x)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -138,7 +138,7 @@ real(sp) :: causal_mask(n_seq,n_seq_x)
 real(sp) :: x2(3*n_embd,n_seq_x)
 real(sp) :: q(n_embd/n_head,n_seq_x), k(n_embd/n_head,n_seq), v(n_embd/n_head,n_seq)
 real(sp) :: yy(n_embd/n_head,n_seq_x)
-integer :: i, j
+integer :: i, j, l
 ! Mask
 if (use_kv_cache) then
     causal_mask = 0
@@ -168,12 +168,12 @@ else
     end do
 end if
 ! Perform attention over each head
-do i = 1, n_head
-    q = x2((i-1)*n_embd/n_head+1:i*n_embd/n_head,:)
-    k = kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,1)
-    v = kv_cache((i-1)*n_embd/n_head+1:i*n_embd/n_head,:,2)
+do l = 1, n_head
+    q = x2((l-1)*n_embd/n_head+1:l*n_embd/n_head,:)
+    k = kv_cache((l-1)*n_embd/n_head+1:l*n_embd/n_head,:,1)
+    v = kv_cache((l-1)*n_embd/n_head+1:l*n_embd/n_head,:,2)
     call attention(yy, n_embd/n_head, n_seq, n_seq_x, q, k, v, causal_mask)
-    y((i-1)*n_embd/n_head+1:i*n_embd/n_head,:) = yy
+    y((l-1)*n_embd/n_head+1:l*n_embd/n_head,:) = yy
 end do
 ! Out projection
 y = linear(y, proj_w, proj_b)

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -248,7 +248,7 @@ integer, intent(in) :: input(n_seq)
 logical, intent(in) :: use_cache
 integer, intent(in) :: byte_decoder(:)
 character(*), intent(in), optional :: stop_text ! Stop if you see this text
-integer, allocatable, intent(out) :: output(:)
+integer, intent(out) :: output(:)
 real(sp), allocatable :: logits(:,:)
 integer :: i
 integer :: n_seq2, n_seq_x

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -294,7 +294,9 @@ do i = 1, n_tokens_to_generate
     end if
     deallocate(logits)
 end do
-output = input2(n_seq+1:)
+do i = 1, n_tokens_to_generate
+    output(i) = input2(n_seq+i)
+end do
 end subroutine
 
 end module

--- a/gpt2.f90
+++ b/gpt2.f90
@@ -192,12 +192,12 @@ y = y + ffn(layer_norm(y, ln2_g, ln2_b, 1e-5_sp), &
     mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b)
 end function
 
-function gpt2(n_vocab, n_ctx, n_seq, n_seq_x, n_embd, n_layer, n_head, input, &
+subroutine gpt2(y, n_vocab, n_ctx, n_seq, n_seq_x, n_embd, n_layer, n_head, input, &
         wte, wpe, &
         mlp_fc_w, mlp_fc_b, mlp_proj_w, mlp_proj_b, &
         attn_w, attn_b, attn_proj_w, attn_proj_b, &
         ln1_g, ln1_b, ln2_g, ln2_b, lnf_g, lnf_b, &
-        use_kv_cache, kv_cache) result(y)
+        use_kv_cache, kv_cache)
 integer, intent(in) :: n_vocab, n_ctx, n_seq, n_seq_x, n_embd, n_layer, n_head
 integer, intent(in) :: input(n_seq)
 real(sp), intent(in) :: wte(n_embd,n_vocab), wpe(n_embd,n_ctx), &
@@ -210,7 +210,7 @@ real(sp), intent(in) :: wte(n_embd,n_vocab), wpe(n_embd,n_ctx), &
     lnf_b(n_embd), lnf_g(n_embd)
 logical, intent(in) :: use_kv_cache
 real(sp), intent(inout) :: kv_cache(n_embd,n_seq,2,n_layer)
-real(sp) :: y(n_vocab,n_seq_x)
+real(sp), intent(out) :: y(n_vocab,n_seq_x)
 real(sp) :: x(n_embd,n_seq_x)
 integer :: i, j
 if (use_kv_cache) then
@@ -237,7 +237,7 @@ x = layer_norm(x, lnf_g, lnf_b, 1e-5)
 !y = matmul(transpose(wte), x)
 call matmul_2d_t(wte, x, y)
 stop "OK"
-end function
+end subroutine
 
 function generate(n_tokens_to_generate, m, &
         n_seq, input, &
@@ -276,7 +276,7 @@ do i = 1, n_tokens_to_generate
         n_seq_x = n_seq2
     end if
     allocate(logits(m%n_vocab, n_seq_x))
-    logits = gpt2(m%n_vocab, m%n_ctx, n_seq2, n_seq_x, m%n_embd, m%n_layer, &
+    call gpt2(logits, m%n_vocab, m%n_ctx, n_seq2, n_seq_x, m%n_embd, m%n_layer, &
             m%n_head, &
             input2, &
             m%wte, m%wpe, &

--- a/linalg_c.f90
+++ b/linalg_c.f90
@@ -36,6 +36,7 @@ contains
     ! C = matmul(transpose(A), B)
     real(sp), intent(in) :: A(:,:), B(:,:)
     real(sp), intent(out) :: C(:,:)
+    print *, "matmul_2d_t"
     call acc_sgemm_t(size(A,2), size(B,2), size(A,1), A, B, C)
     end subroutine
 

--- a/linalg_c.f90
+++ b/linalg_c.f90
@@ -36,7 +36,7 @@ contains
     ! C = matmul(transpose(A), B)
     real(sp), intent(in) :: A(:,:), B(:,:)
     real(sp), intent(out) :: C(:,:)
-    print *, "matmul_2d_t"
+    !print *, "matmul_2d_t"
     call acc_sgemm_t(size(A,2), size(B,2), size(A,1), A, B, C)
     end subroutine
 

--- a/linalg_openblas.c
+++ b/linalg_openblas.c
@@ -14,5 +14,9 @@ void acc_sgemm_t(int m, int n, int k, float *A, float *B, float *C) {
     //A[k][m] (to be transposed)
     //B[k][n]
     //C[m][n]
+    printf("acc_sgemm_t: %d %d %d\n", m, n, k);
+    // TODO: A seems correct, but B[0] is incorrect:
+    printf("Values: %f %f %f\n", A[0], B[0], C[0]);
     cblas_sgemm(CblasColMajor, CblasTrans, CblasNoTrans, m, n, k, 1.0, A, k, B, k, 0.0, C, m);
+    printf("BLAS done\n");
 }

--- a/linalg_openblas.c
+++ b/linalg_openblas.c
@@ -14,9 +14,8 @@ void acc_sgemm_t(int m, int n, int k, float *A, float *B, float *C) {
     //A[k][m] (to be transposed)
     //B[k][n]
     //C[m][n]
-    printf("acc_sgemm_t: %d %d %d\n", m, n, k);
-    // TODO: A seems correct, but B[0] is incorrect:
-    printf("Values: %f %f %f\n", A[0], B[0], C[0]);
+//    printf("acc_sgemm_t: %d %d %d\n", m, n, k);
+//    printf("Values: %f %f %f\n", A[0], B[0], C[0]);
     cblas_sgemm(CblasColMajor, CblasTrans, CblasNoTrans, m, n, k, 1.0, A, k, B, k, 0.0, C, m);
-    printf("BLAS done\n");
+//    printf("BLAS done\n");
 }

--- a/tests/test_chat.f90
+++ b/tests/test_chat.f90
@@ -19,5 +19,5 @@ inputs = [ &
     string("What color is snow?"), &
     string("What color do plants usually have?") &
     ]
-call chat(inputs(:3))
+call chat(.true., inputs(:3))
 end program

--- a/tests/test_more_inputs.f90
+++ b/tests/test_more_inputs.f90
@@ -11,19 +11,19 @@ integer, allocatable :: input(:), output(:)
 
 call load_model("model.dat", m)
 
-call gpt2_driver2("Ondřej Čertík was born in ", 13, m, input, output)
+call gpt2_driver2("Ondřej Čertík was born in", 13, m, input, output)
 print *
 print *, "TESTS:"
 call test(input, input_ref, "Input")
 call test(output, output_ref, "Output")
 
-call gpt2_driver2("San Francisco is ", 8, m, input, output)
+call gpt2_driver2("San Francisco is", 8, m, input, output)
 print *
 print *, "TESTS:"
 call test(input, [15017, 6033, 318], "Input")
 call test(output, [257, 1748, 286, 517, 621, 352, 1510, 661], "Output")
 
-call gpt2_driver2("Cars are ", 13, m, input, output)
+call gpt2_driver2("Cars are", 13, m, input, output)
 print *
 print *, "TESTS:"
 call test(input, [34, 945, 389], "Input")

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -9,11 +9,13 @@ contains
 
 function c2s(x) result(y)
 integer(1), intent(in) :: x(:)
+integer(1) :: xx(size(x))
 character(:), allocatable :: y
 integer :: i
+xx = x
 allocate(character(size(x)) :: y)
 do i = 1, size(x)
-    y(i:i) = char(int(x(i),4))
+    y(i:i) = char(int(xx(i),4))
 end do
 end function
 

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -115,8 +115,16 @@ type(string), intent(in) :: intokens(:)
 integer, intent(in) :: idx
 type(string), allocatable :: tokens(:)
 type(string) :: merged_token
+integer :: i
 merged_token%s = intokens(idx)%s // intokens(idx+1)%s
-tokens = [intokens(:idx-1), merged_token, intokens(idx+2:)]
+allocate(tokens(size(intokens)-1))
+do i = 1, idx-1
+    tokens(i) = intokens(i)
+end do
+tokens(idx) = merged_token
+do i = idx+2, size(intokens)
+    tokens(i-1) = intokens(i)
+end do
 end function
 
 function merge_utf8_pairs(intokens) result(tokens)

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -219,7 +219,9 @@ do
     deallocate(tmp2)
 end do
 allocate(tokens2(n_tokens))
-tokens2 = tokens(:n_tokens)
+do i = 1, n_tokens
+    tokens2(i) = tokens(i)
+end do
 end function
 
 function decode(tokens, idx, decoder_txt, byte_decoder) result(output)

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -131,7 +131,7 @@ function merge_utf8_pairs(intokens) result(tokens)
 ! Merge all UTF-8 character pairs
 type(string), intent(in) :: intokens(:)
 type(string), allocatable :: tokens(:)
-integer :: i, j
+integer :: i, j, ic
 logical :: one_more_pass
 allocate(tokens(size(intokens)))
 tokens = intokens
@@ -142,12 +142,15 @@ j = 1
 do while(one_more_pass)
     one_more_pass = .false.
     do i = j, size(tokens)-1
-        if (len(tokens(i)%s) == 1 .and. iachar(tokens(i)%s(1:1)) >= 128) then
-            tokens = merge_pair(tokens, i)
-            one_more_pass = .true.
-            j = i + 1
-!            print *, "pass"
-            exit
+        if (len(tokens(i)%s) == 1) then
+            ic = iachar(tokens(i)%s(1:1))
+            if (ic < 0) ic = ic + 256
+            if (ic >= 128) then
+                tokens = merge_pair(tokens, i)
+                one_more_pass = .true.
+                j = i + 1
+                exit
+            end if
         end if
     end do
 end do

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -13,7 +13,7 @@ character(:), allocatable :: y
 integer :: i
 allocate(character(size(x)) :: y)
 do i = 1, size(x)
-    y(i:i) = char(x(i))
+    y(i:i) = char(int(x(i),4))
 end do
 end function
 

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -256,7 +256,10 @@ do
     ! However for GPT-2 it seems only range 0-323 is used from UTF-32.
     c = utf8_to_codepoint(output2, i)
     ! [0,324] -> [0,255]
-    if (c < 0 .or. c > ubound(byte_decoder,1)) error stop "Codepoint out of range for byte decoder"
+    if (c < 0 .or. c > ubound(byte_decoder,1)) then
+        print *, "Codepoint out of range for byte decoder:", c, ubound(byte_decoder,1)
+        error stop "Codepoint out of range for byte decoder"
+    end if
     tmp = achar(byte_decoder(c))
     output = output // tmp
     if (i == len(output2)) exit

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -8,12 +8,12 @@ end type
 contains
 
 function c2s(x) result(y)
-character, intent(in) :: x(:)
+integer(1), intent(in) :: x(:)
 character(:), allocatable :: y
 integer :: i
 allocate(character(size(x)) :: y)
 do i = 1, size(x)
-    y(i:i) = x(i)
+    y(i:i) = char(x(i))
 end do
 end function
 
@@ -62,7 +62,7 @@ end function
 function word_idx(word, idx, decoder_txt) result(token)
 character(*), intent(in) :: word
 integer, intent(in) :: idx(0:)
-character, intent(in) :: decoder_txt(:)
+integer(1), intent(in) :: decoder_txt(:)
 integer :: token
 integer :: i
 ! This is O(n) search instead of O(1) lookup in a dictionary, so it is slow
@@ -148,7 +148,7 @@ function bpe(token, vocab_idx, vocab_txt) result(tokens)
 ! Takes a token as a string, and returns bpe tokens as an array of strings
 character(*), intent(in) :: token
 integer, intent(in) :: vocab_idx(0:)
-character, intent(in) :: vocab_txt(:)
+integer(1), intent(in) :: vocab_txt(:)
 type(string), allocatable :: tokens(:)
 integer, allocatable :: pair_scores(:)
 integer :: not_found, merge_pair_idx
@@ -189,7 +189,7 @@ function encode(input, idx, decoder_txt, vocab_idx, vocab_txt, byte_encoder) &
         result(tokens2)
 character(*), intent(in) :: input
 integer, intent(in) :: idx(0:), vocab_idx(0:), byte_encoder(0:)
-character, intent(in) :: decoder_txt(:), vocab_txt(:)
+integer(1), intent(in) :: decoder_txt(:), vocab_txt(:)
 integer, parameter :: max_tokens = 2048
 integer :: tokens(max_tokens)
 integer, allocatable :: tokens2(:)
@@ -226,7 +226,7 @@ end function
 
 function decode(tokens, idx, decoder_txt, byte_decoder) result(output)
 integer, intent(in) :: tokens(:), idx(0:), byte_decoder(0:)
-character, intent(in) :: decoder_txt(:)
+integer(1), intent(in) :: decoder_txt(:)
 character(:), allocatable :: output
 character(:), allocatable :: output2, tmp
 integer :: i, c

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -258,10 +258,12 @@ do
     ! [0,324] -> [0,255]
     if (c < 0 .or. c > ubound(byte_decoder,1)) then
         print *, "Codepoint out of range for byte decoder:", c, ubound(byte_decoder,1)
-        error stop "Codepoint out of range for byte decoder"
+        ! We skip this, to allow LFortran to run
+!        error stop "Codepoint out of range for byte decoder"
+    else
+        tmp = achar(byte_decoder(c))
+        output = output // tmp
     end if
-    tmp = achar(byte_decoder(c))
-    output = output // tmp
     if (i == len(output2)) exit
     i = i + 1
 end do

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -242,13 +242,25 @@ integer, intent(in) :: tokens(:), idx(0:), byte_decoder(0:)
 integer(1), intent(in) :: decoder_txt(:)
 character(:), allocatable :: output
 character(:), allocatable :: output2, tmp
-integer :: i, c
-allocate(character(0) :: output2) ! Fix GFortran warning
-output2 = ""
+integer, parameter :: max_len = 4096
+integer(1) :: output3(max_len)
+integer(1), allocatable :: output4(:)
+integer :: i, j, c, pos
+pos = 0
 do i = 1, size(tokens)
     if (tokens(i) < 0) error stop "tokens(i) < 0"
-    output2 = output2 // c2s(decoder_txt(idx(tokens(i))+1:idx(tokens(i)+1)))
+    ! output2 = output2 // (decoder_txt(idx(tokens(i))+1:idx(tokens(i)+1)))
+    do j = idx(tokens(i))+1, idx(tokens(i)+1)
+        pos = pos + 1
+        output3(pos) = decoder_txt(j)
+    end do
 end do
+allocate(character(0) :: output2) ! Fix GFortran warning
+allocate(output4(pos))
+do j = 1, pos
+    output4(j) = output3(j)
+end do
+output2 = c2s(output4)
 i = 1
 output = ""
 do
@@ -259,7 +271,7 @@ do
     if (c < 0 .or. c > ubound(byte_decoder,1)) then
         print *, "Codepoint out of range for byte decoder:", c, ubound(byte_decoder,1)
         ! We skip this, to allow LFortran to run
-!        error stop "Codepoint out of range for byte decoder"
+        error stop "Codepoint out of range for byte decoder"
     else
         tmp = achar(byte_decoder(c))
         output = output // tmp

--- a/tokenizer.f90
+++ b/tokenizer.f90
@@ -123,6 +123,7 @@ type(string), intent(in) :: intokens(:)
 type(string), allocatable :: tokens(:)
 integer :: i, j
 logical :: one_more_pass
+allocate(tokens(size(intokens)))
 tokens = intokens
 one_more_pass = .true.
 !print *, "merge_utf8_pairs:", size(tokens)


### PR DESCRIPTION
This is a Draft PR, since we will slowly remove all workarounds. All tests pass using GFortran. For LFortran, `gpt2`, `test_basic_input` works. `test_more_inputs` works sometimes (there is some bug there). `test_chat` only works inside ctest.