### PR TITLE
Use GGUF to store model weights

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,16 @@ jobs:
           variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
 
+      - name: Install GGUF
+        shell: bash -e -x -l {0}
+        run: |
+            git clone https://github.com/ggerganov/llama.cpp
+            cd llama.cpp
+            git checkout 4e9a7f7f7fb6acbddd1462909c8d696e38edbfcc
+            cd gguf-py
+            pip install .
+            cd ../..
+
       - name: Build and run
         shell: bash -l {0}
         run: |

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -16,8 +16,8 @@ make
 time OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 ./gpt2
 
 rm model.gguf
-curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
-#time OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 ./gpt2
+curl -o model.gguf -L https://huggingface.co/certik/fastGPT/resolve/main/model_fastgpt_124M_v2.gguf
+time OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 ./gpt2
 
 rm gpt2
 python pt.py

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -17,7 +17,7 @@ time OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 ./gpt2
 
 rm model.gguf
 curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
-time OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 ./gpt2
+#time OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 ./gpt2
 
 rm gpt2
 python pt.py

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -15,7 +15,7 @@ cmake -DFASTGPT_BLAS=OpenBLAS .
 make
 time OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 ./gpt2
 
-rm model.dat
+rm model.gguf
 curl -o model.dat -L https://huggingface.co/datasets/certik/fastGPT/resolve/main/model_fastgpt_124M_v1.dat
 time OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 ./gpt2
 

--- a/create_model.py
+++ b/create_model.py
@@ -157,7 +157,7 @@ def convert(params, n_head, n_ctx, idx, decoder_txt,
     assert np.size(wte, 1) == n_embd
 
     model_type = 0xfa51697 # fastGPT
-    model_version = 1
+    model_version = 2
     header = np.array([model_type, model_version, n_vocab, n_ctx, n_embd, n_layer, n_head,
         len(idx),len(decoder_txt.encode("utf-8")),
         len(vocab_idx),len(vocab_txt.encode("utf-8")),len(byte_decoder)], dtype=np.int32)

--- a/create_model.py
+++ b/create_model.py
@@ -158,31 +158,11 @@ def convert(params, n_head, n_ctx, idx, decoder_txt,
 
     model_type = 0xfa51697 # fastGPT
     model_version = 1
-
-    # Save the model
-    f = open("model2.dat", "w")
     header = np.array([model_type, model_version, n_vocab, n_ctx, n_embd, n_layer, n_head,
         len(idx),len(decoder_txt.encode("utf-8")),
         len(vocab_idx),len(vocab_txt.encode("utf-8")),len(byte_decoder)], dtype=np.int32)
-    header.tofile(f)
-    wte.tofile(f); wpe.tofile(f)
-    mlp_fc_w.tofile(f); mlp_fc_b.tofile(f)
-    mlp_proj_w.tofile(f); mlp_proj_b.tofile(f)
-    attn_w.tofile(f); attn_b.tofile(f)
-    attn_proj_w.tofile(f); attn_proj_b.tofile(f)
-    ln1_b.tofile(f); ln1_g.tofile(f)
-    ln2_b.tofile(f); ln2_g.tofile(f)
-    lnf_b.tofile(f); lnf_g.tofile(f)
-    idx.tofile(f)
-    f.write(decoder_txt)
-    vocab_idx.tofile(f)
-    f.write(vocab_txt)
-    byte_decoder.tofile(f)
 
-    t2 = clock()
-    print("Save time: ", t2-t1)
-
-    # Save to GGUF
+    # Save the model to GGUF
     g = gguf.GGUFWriter("model.gguf", None)
     g.add_tensor("header", header)
     g.add_tensor("wte", wte); g.add_tensor("wpe", wpe)
@@ -205,6 +185,9 @@ def convert(params, n_head, n_ctx, idx, decoder_txt,
     g.write_kv_data_to_file()
     g.write_tensors_to_file()
     g.close()
+
+    t2 = clock()
+    print("Save time: ", t2-t1)
 
 
 def load_decoder(filename):

--- a/create_model.py
+++ b/create_model.py
@@ -183,7 +183,7 @@ def convert(params, n_head, n_ctx, idx, decoder_txt,
     print("Save time: ", t2-t1)
 
     # Save to GGUF
-    g = gguf.GGUFWriter("model.gguf", "gpt2")
+    g = gguf.GGUFWriter("model.gguf", None)
     g.add_tensor("header", header)
     g.add_tensor("wte", wte); g.add_tensor("wpe", wpe)
     g.add_tensor("mlp_fc_w", mlp_fc_w); g.add_tensor("mlp_fc_b", mlp_fc_b)

--- a/create_model.py
+++ b/create_model.py
@@ -196,6 +196,7 @@ def convert(params, n_head, n_ctx, idx, decoder_txt,
     # * .offset: the offset of the kv entry
     # * 8: The i64 length of the key string
     # * 4: The i32 type of the value
+    assert g.fields[data_offset_name].offset == 24
     offset_offset = g.fields[data_offset_name].offset + 8 + \
         len(data_offset_name) + 4
     print("offset offset:", offset_offset)

--- a/driver.f90
+++ b/driver.f90
@@ -58,14 +58,27 @@ type(model_t), intent(out) :: m
 ! We use the following fastGPT model type number
 !   fastGPT (digits look similar to the letters they represent)
 ! 0xfa51697 = 262477463
+
+! We read the offset to the data section at this position, which is the first
+! variable in the metadata, the name is "general.data_offset", type i32.
+integer, parameter :: offset_offset = &
+    ! header
+    4 + & ! u8[4] magic
+    4 + & ! u32 version
+    8 + & ! u64 n_arrays
+    8 + & ! u64 n_kv
+    ! kv
+    8 + & ! u64 n_str
+    19 + & ! len("general.data_offset")
+    4 ! u32 type of value
 integer, parameter :: current_model_mark = 262477463
 integer, parameter :: current_model_version = 1
 integer :: model_mark
 integer :: u
 integer :: data_offset
 open(newunit=u, file=filename, form="unformatted", access="stream", status="old")
-! TODO: We need an easy way to extract this data offset from the gguf file
-data_offset = 1056
+call fseek(u, offset_offset, 0)
+read(u) data_offset
 call fseek(u, data_offset, 0)
 read(u) model_mark
 if (model_mark /= current_model_mark) then

--- a/driver.f90
+++ b/driver.f90
@@ -72,7 +72,7 @@ integer, parameter :: offset_offset = &
     19 + & ! len("general.data_offset")
     4 ! u32 type of value
 integer, parameter :: current_model_mark = 262477463
-integer, parameter :: current_model_version = 1
+integer, parameter :: current_model_version = 2
 integer :: model_mark
 integer :: u
 integer :: data_offset

--- a/driver.f90
+++ b/driver.f90
@@ -31,6 +31,27 @@ end do
 close(u)
 end subroutine
 
+! Aligns file position in `u` to 32 byte boundary after `A` was read
+subroutine align_i4(u, A)
+integer, intent(in) :: u
+integer, intent(in) :: A(..)
+integer :: n, alignment
+alignment = 32
+n = size(A)*4
+call fseek(u, alignment-modulo(n,alignment), 1)
+end subroutine
+
+subroutine align_str(u, A)
+integer, intent(in) :: u
+character, intent(in) :: A(:)
+integer :: n, alignment
+alignment = 32
+n = size(A)
+if (modulo(n, alignment) /= 0) then
+    call fseek(u, alignment-modulo(n,alignment), 1)
+end if
+end subroutine
+
 subroutine load_model(filename, m)
 character(*), intent(in) :: filename
 type(model_t), intent(out) :: m
@@ -41,7 +62,11 @@ integer, parameter :: current_model_mark = 262477463
 integer, parameter :: current_model_version = 1
 integer :: model_mark
 integer :: u
+integer :: data_offset
 open(newunit=u, file=filename, form="unformatted", access="stream", status="old")
+! TODO: We need an easy way to extract this data offset from the gguf file
+data_offset = 1056
+call fseek(u, data_offset, 0)
 read(u) model_mark
 if (model_mark /= current_model_mark) then
     print *, "Found:", model_mark
@@ -56,6 +81,7 @@ if (m%model_file_version /= current_model_version) then
 end if
 read(u) m%n_vocab, m%n_ctx, m%n_embd, m%n_layer, m%n_head, m%n_decoder_idx, &
     m%n_decoder_txt, m%n_vocab_idx, m%n_vocab_txt, m%n_byte_encoder
+call fseek(u, 16, 1) ! Pad the 12 element i32 array to 32 byte boundary
 allocate(m%wte(m%n_embd,m%n_vocab), m%wpe(m%n_embd,m%n_ctx), &
     m%mlp_fc_w(4*m%n_embd,m%n_embd,m%n_layer), m%mlp_fc_b(4*m%n_embd,m%n_layer), &
     m%mlp_proj_w(m%n_embd,4*m%n_embd,m%n_layer), m%mlp_proj_b(m%n_embd,m%n_layer), &
@@ -75,9 +101,15 @@ read(u) m%wte, m%wpe, &
     m%ln1_b, m%ln1_g, &
     m%ln2_b, m%ln2_g, &
     m%lnf_b, m%lnf_g, &
-    m%decoder_idx, m%decoder_txt, &
-    m%vocab_idx, m%vocab_txt, &
-    m%byte_encoder
+    m%decoder_idx
+call align_i4(u, m%decoder_idx)
+read(u) m%decoder_txt
+call align_str(u, m%decoder_txt)
+read(u) m%vocab_idx
+call align_i4(u, m%vocab_idx)
+read(u) m%vocab_txt
+call align_str(u, m%vocab_txt)
+read(u) m%byte_encoder
 close(u)
 end subroutine
 
@@ -92,7 +124,7 @@ call load_input("input", input_txt, n_tokens_to_generate)
 ! Load the model
 print "(a)", "Loading the model..."
 call cpu_time(t1)
-call load_model("model.dat", m)
+call load_model("model.gguf", m)
 call cpu_time(t2)
 print "(a,f8.3,a,i2)", "    done. Time:", t2-t1, "s, Model file version:", m%model_file_version
 print *
@@ -235,7 +267,7 @@ type(string), optional, intent(in) :: inputs(:)
 type(model_t) :: m
 character(:), allocatable :: prompt, input, output
 integer :: i, n_prompts
-call load_model("model.dat", m)
+call load_model("model.gguf", m)
 prompt = "Your name is fastGPT and you are an AI bot. The user will ask you &
 &questions and you answer in a nice, truthful, short way." // LF // "&
 &User: What is the capital of Czechia?" // LF // "&

--- a/tests/test_more_inputs.f90
+++ b/tests/test_more_inputs.f90
@@ -9,7 +9,7 @@ integer, parameter :: output_ref(*) = [1248, 5332, 287, 262, 7404, 286, &
     25370, 254, 368, 83, 6557, 81, 11]
 integer, allocatable :: input(:), output(:)
 
-call load_model("model.dat", m)
+call load_model("model.gguf", m)
 
 call gpt2_driver2("Ondřej Čertík was born in", 13, m, input, output)
 print *


### PR DESCRIPTION
Here are the two lowest models. 124M:
```console
$ gguf-dump model_fastgpt_124M_v2.gguf
* Loading: model_fastgpt_124M_v2.gguf
* File is LITTLE endian, script is running on a LITTLE endian host.

* Dumping 4 key/value pair(s)
      1: UINT32     |        1 | GGUF.version = 3
      2: UINT64     |        1 | GGUF.tensor_count = 22
      3: UINT64     |        1 | GGUF.kv_count = 1
      4: INT32      |        1 | general.data_offset = 1088

* Dumping 22 tensor(s)
      1:         12 |    12,     1,     1,     1 | I32     | header
      2:   38597376 |   768, 50257,     1,     1 | F32     | wte
      3:     786432 |   768,  1024,     1,     1 | F32     | wpe
      4:   28311552 |  3072,   768,    12,     1 | F32     | mlp_fc_w
      5:      36864 |  3072,    12,     1,     1 | F32     | mlp_fc_b
      6:   28311552 |   768,  3072,    12,     1 | F32     | mlp_proj_w
      7:       9216 |   768,    12,     1,     1 | F32     | mlp_proj_b
      8:   21233664 |  2304,   768,    12,     1 | F32     | attn_w
      9:      27648 |  2304,    12,     1,     1 | F32     | attn_b
     10:    7077888 |   768,   768,    12,     1 | F32     | attn_proj_w
     11:       9216 |   768,    12,     1,     1 | F32     | attn_proj_b
     12:       9216 |   768,    12,     1,     1 | F32     | ln1_b
     13:       9216 |   768,    12,     1,     1 | F32     | ln1_g
     14:       9216 |   768,    12,     1,     1 | F32     | ln2_b
     15:       9216 |   768,    12,     1,     1 | F32     | ln2_g
     16:        768 |   768,     1,     1,     1 | F32     | lnf_b
     17:        768 |   768,     1,     1,     1 | F32     | lnf_g
     18:      50258 | 50258,     1,     1,     1 | I32     | idx
     19:     356735 | 356735,    1,     1,     1 | I8      | decoder_txt
     20:      50002 | 50002,     1,     1,     1 | I32     | vocab_idx
     21:     406304 | 406304,    1,     1,     1 | I8      | vocab_txt
     22:        256 |   256,     1,     1,     1 | I32     | byte_decoder
```
and 355M:
```console
$ gguf-dump model_fastgpt_355M_v2.gguf 
* Loading: model_fastgpt_355M_v2.gguf
* File is LITTLE endian, script is running on a LITTLE endian host.

* Dumping 4 key/value pair(s)
      1: UINT32     |        1 | GGUF.version = 3
      2: UINT64     |        1 | GGUF.tensor_count = 22
      3: UINT64     |        1 | GGUF.kv_count = 1
      4: INT32      |        1 | general.data_offset = 1088

* Dumping 22 tensor(s)
      1:         12 |    12,     1,     1,     1 | I32     | header
      2:   51463168 |  1024, 50257,     1,     1 | F32     | wte
      3:    1048576 |  1024,  1024,     1,     1 | F32     | wpe
      4:  100663296 |  4096,  1024,    24,     1 | F32     | mlp_fc_w
      5:      98304 |  4096,    24,     1,     1 | F32     | mlp_fc_b
      6:  100663296 |  1024,  4096,    24,     1 | F32     | mlp_proj_w
      7:      24576 |  1024,    24,     1,     1 | F32     | mlp_proj_b
      8:   75497472 |  3072,  1024,    24,     1 | F32     | attn_w
      9:      73728 |  3072,    24,     1,     1 | F32     | attn_b
     10:   25165824 |  1024,  1024,    24,     1 | F32     | attn_proj_w
     11:      24576 |  1024,    24,     1,     1 | F32     | attn_proj_b
     12:      24576 |  1024,    24,     1,     1 | F32     | ln1_b
     13:      24576 |  1024,    24,     1,     1 | F32     | ln1_g
     14:      24576 |  1024,    24,     1,     1 | F32     | ln2_b
     15:      24576 |  1024,    24,     1,     1 | F32     | ln2_g
     16:       1024 |  1024,     1,     1,     1 | F32     | lnf_b
     17:       1024 |  1024,     1,     1,     1 | F32     | lnf_g
     18:      50258 | 50258,     1,     1,     1 | I32     | idx
     19:     356735 | 356735,    1,     1,     1 | I8      | decoder_txt
     20:      50002 | 50002,     1,     1,     1 | I32     | vocab_idx
     21:     406304 | 406304,    1,     1,     1 | I8      | vocab_txt
     22:        256 |   256,     1,     1,     1 | I32     | byte_decoder
```